### PR TITLE
[test] Add unit tests and also enable to run unit tests using WebGL2 backend.

### DIFF
--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -2,10 +2,10 @@
 |----|------|--------|-------|-----|
 | ADD | yes | no | yes | no|
 | AVERAGE_POOL_2D | yes | yes| yes | yes |
-| CONCATENATION | yes | no| yes | no |
+| CONCATENATION | yes | yes| yes | yes |
 | CONV_2D | yes | yes| yes | yes |
 | DEPTHWISE_CONV_2D | yes | yes| yes | yes |
-| MAX_POOL_2D |  yes | yes| yes | no |
+| MAX_POOL_2D |  yes | yes| yes | yes |
 | MUL |  yes | no | yes | no|
-| RESHAPE |  yes | yes| yes | no |
-| SOFTMAX |  yes | no | yes | no |
+| RESHAPE |  yes | yes| yes | yes |
+| SOFTMAX |  yes | yes | yes | yes |

--- a/docs/supported_ops.md
+++ b/docs/supported_ops.md
@@ -2,8 +2,10 @@
 |----|------|--------|-------|-----|
 | ADD | yes | no | yes | no|
 | AVERAGE_POOL_2D | yes | yes| yes | yes |
-| CONCATENATION | yes | yes| yes | yes |
+| CONCATENATION | yes | no| yes | no |
 | CONV_2D | yes | yes| yes | yes |
 | DEPTHWISE_CONV_2D | yes | yes| yes | yes |
-| MAX_POOL_2D |  yes | yes| yes | yes |
+| MAX_POOL_2D |  yes | yes| yes | no |
 | MUL |  yes | no | yes | no|
+| RESHAPE |  yes | yes| yes | no |
+| SOFTMAX |  yes | no | yes | no |

--- a/src/nn/Enums.js
+++ b/src/nn/Enums.js
@@ -332,7 +332,7 @@ export const OperationCode = {
    * * 10: An INT32 value, and has to be one of the {@link FuseCode} values.
    *       Specifies the activation to invoke on the result of each addition.
    *
-   * Inputs (explicit padding):
+   * Inputs (implicit padding):
    * * 0: A 4-D tensor, of shape [batches, height, width, depth_in], specifying the input.
    * * 1: A 4-D tensor, of shape [1, filter_height, filter_width, depth_out],
    *      specifying the filter.

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,9 @@
     <script src="../dist/webml-polyfill.js"></script>
     <script src="./utils.js"></script>
     <script>
+      window.onload = setOptions;
+    </script>
+    <script>
       mocha.setup('bdd');
     </script>
     <script src="./base/base.js"></script>
@@ -20,7 +23,17 @@
     <script src="./unit-test/test-Compilation.js"></script>
     <script src="./unit-test/test-Execution.js"></script>
     <script src="./operations/add.js"></script>
+    <script src="./operations/avg_pool_2d.js"></script>
+    <script src="./operations/concatenation_0.js"></script>
+    <script src="./operations/concatenation_1.js"></script>
+    <script src="./operations/concatenation_2.js"></script>
+    <script src="./operations/concatenation_3.js"></script>
+    <script src="./operations/concatenation_neg1.js"></script>
+    <script src="./operations/max_pool_2d.js"></script>
     <script src="./operations/mul.js"></script>
+    <script src="./operations/reshape.js"></script>
+    <script src="./operations/reshape_neg1.js"></script>
+    <script src="./operations/softmax.js"></script>
     <script>
       mocha.globals(['jQuery']);
       mocha.run();

--- a/test/operations/add.js
+++ b/test/operations/add.js
@@ -4,10 +4,10 @@ describe('Add Test', function() {
   const nn = navigator.ml.getNeuralNetworkContext();
   const value0 = 0.4;
   const value1 = 0.5;
-    
+
   it('check result', async function() {
     let operandIndex = 0;
-    let model = await nn.createModel();
+    let model = await nn.createModel(options);
     const float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
     const tensorLength = product(float32TensorType.dimensions);
 
@@ -34,7 +34,7 @@ describe('Add Test', function() {
     let compilation = await model.createCompilation();
 
     compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
-    
+
     await compilation.finish();
 
     let execution = await compilation.createExecution();

--- a/test/operations/avg_pool_2d.js
+++ b/test/operations/avg_pool_2d.js
@@ -1,0 +1,63 @@
+describe('Average_pool_2d Test', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it('check result', async function() {
+    let model = await nn.createModel(options);
+    const float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 1]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+
+    // no padding on the left
+    model.setOperandValue(1, new Int32Array([0]));
+    // no padding on the right
+    model.setOperandValue(2, new Int32Array([0]));
+    // no padding on the top
+    model.setOperandValue(3, new Int32Array([0]));
+    // no padding on the bottom
+    model.setOperandValue(4, new Int32Array([0]));
+    // set the stride as 1 when walking through input in the ‘width’ dimension
+    model.setOperandValue(5, new Int32Array([1]));
+    // set the stride as 1 when walking through input in the ‘height’ dimension
+    model.setOperandValue(6, new Int32Array([1]));
+    // set the filter width as 1
+    model.setOperandValue(7, new Int32Array([1]));
+    // set the filter height as 1
+    model.setOperandValue(8, new Int32Array([1]));
+    model.setOperandValue(9, new Int32Array([nn.FUSED_NONE]));
+
+    model.addOperand(float32TensorType);
+    model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+
+    model.identifyInputsAndOutputs([0], [10]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([1.0, 2.0, 3.0, 4.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(tensorLength);
+    execution.setOutput(0, outputData);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < tensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], inputData0[i]));
+    }
+  });
+});

--- a/test/operations/concatenation_0.js
+++ b/test/operations/concatenation_0.js
@@ -1,0 +1,54 @@
+describe('Concatenation Test for 4-D input with axis being 0', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it('check result', async function() {
+    let model = await nn.createModel(options);
+
+    let float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 2]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand(float32TensorType);
+    let inputData1 = new Float32Array(tensorLength);
+    inputData1.set([201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0,
+                    209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0]);
+    model.setOperandValue(1, inputData1);
+    model.addOperand({type: nn.INT32});
+    let axis = 0;
+    model.setOperandValue(2, new Int32Array([axis]));
+
+    let outputFloat32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2, 2]};
+    const outputTensorLength = product(outputFloat32TensorType.dimensions);
+
+    model.addOperand(outputFloat32TensorType);
+    model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+
+    model.identifyInputsAndOutputs([0], [3]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+                    109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(outputTensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    let expectedData = new Float32Array(outputTensorLength);
+    expectedData.set([101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+                      109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0,
+                      201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0,
+                      209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0]);
+
+    for (let i = 0; i < outputTensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], expectedData[i]));
+    }
+  });
+});

--- a/test/operations/concatenation_1.js
+++ b/test/operations/concatenation_1.js
@@ -1,0 +1,54 @@
+describe('Concatenation Test for 4-D input with axis being 1', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it('check result', async function() {
+    let model = await nn.createModel(options);
+
+    let float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 2]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand(float32TensorType);
+    let inputData1 = new Float32Array(tensorLength);
+    inputData1.set([201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0,
+                    209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0]);
+    model.setOperandValue(1, inputData1);
+    model.addOperand({type: nn.INT32});
+    let axis = 1;
+    model.setOperandValue(2, new Int32Array([axis]));
+
+    let outputFloat32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 4, 2, 2]};
+    const outputTensorLength = product(outputFloat32TensorType.dimensions);
+
+    model.addOperand(outputFloat32TensorType);
+    model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+
+    model.identifyInputsAndOutputs([0], [3]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+                    109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(outputTensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    let expectedData = new Float32Array(outputTensorLength);
+    expectedData.set([101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+                      201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0,
+                      109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0,
+                      209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0]);
+
+    for (let i = 0; i < outputTensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], expectedData[i]));
+    }
+  });
+});

--- a/test/operations/concatenation_2.js
+++ b/test/operations/concatenation_2.js
@@ -1,0 +1,57 @@
+describe('Concatenation Test for 4-D input with axis being 2', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it('check result', async function() {
+    let model = await nn.createModel(options);
+
+    let float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 2]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand(float32TensorType);
+    let inputData1 = new Float32Array(tensorLength);
+    inputData1.set([201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0,
+                    209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0]);
+    model.setOperandValue(1, inputData1);
+    model.addOperand({type: nn.INT32});
+    let axis = 2;
+    model.setOperandValue(2, new Int32Array([axis]));
+
+    let outputFloat32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 4, 2]};
+    const outputTensorLength = product(outputFloat32TensorType.dimensions);
+
+    model.addOperand(outputFloat32TensorType);
+    model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+
+    model.identifyInputsAndOutputs([0], [3]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+                    109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(outputTensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    let expectedData = new Float32Array(outputTensorLength);
+    expectedData.set([101.0, 102.0, 103.0, 104.0,
+                      201.0, 202.0, 203.0, 204.0,
+                      105.0, 106.0, 107.0, 108.0,
+                      205.0, 206.0, 207.0, 208.0,
+                      109.0, 110.0, 111.0, 112.0,
+                      209.0, 210.0, 211.0, 212.0,
+                      113.0, 114.0, 115.0, 116.0,
+                      213.0, 214.0, 215.0, 216.0]);
+    for (let i = 0; i < outputTensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], expectedData[i]));
+    }
+  });
+});

--- a/test/operations/concatenation_3.js
+++ b/test/operations/concatenation_3.js
@@ -1,0 +1,58 @@
+describe('Concatenation Test for 4-D input with axis being 3', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it('check result', async function() {
+    let model = await nn.createModel(options);
+
+    let float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 2]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand(float32TensorType);
+    let inputData1 = new Float32Array(tensorLength);
+    inputData1.set([201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0,
+                    209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0]);
+    model.setOperandValue(1, inputData1);
+    model.addOperand({type: nn.INT32});
+    let axis = 3;
+    model.setOperandValue(2, new Int32Array([axis]));
+
+    let outputFloat32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 4]};
+    const outputTensorLength = product(outputFloat32TensorType.dimensions);
+
+    model.addOperand(outputFloat32TensorType);
+    model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+
+    model.identifyInputsAndOutputs([0], [3]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+                    109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(outputTensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    let expectedData = new Float32Array(outputTensorLength);
+    expectedData.set([101.0, 102.0, 201.0, 202.0,
+                      103.0, 104.0, 203.0, 204.0,
+                      105.0, 106.0, 205.0, 206.0,
+                      107.0, 108.0, 207.0, 208.0,
+                      109.0, 110.0, 209.0, 210.0,
+                      111.0, 112.0, 211.0, 212.0,
+                      113.0, 114.0, 213.0, 214.0,
+                      115.0, 116.0, 215.0, 216.0]);
+
+    for (let i = 0; i < outputTensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], expectedData[i]));
+    }
+  });
+});

--- a/test/operations/concatenation_neg1.js
+++ b/test/operations/concatenation_neg1.js
@@ -1,0 +1,58 @@
+describe('Concatenation Test for 4-D input with axis being -1', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it('check result', async function() {
+    let model = await nn.createModel(options);
+
+    let float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 2]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand(float32TensorType);
+    let inputData1 = new Float32Array(tensorLength);
+    inputData1.set([201.0, 202.0, 203.0, 204.0, 205.0, 206.0, 207.0, 208.0,
+                    209.0, 210.0, 211.0, 212.0, 213.0, 214.0, 215.0, 216.0]);
+    model.setOperandValue(1, inputData1);
+    model.addOperand({type: nn.INT32});
+    let axis = -1;
+    model.setOperandValue(2, new Int32Array([axis]));
+
+    let outputFloat32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 4]};
+    const outputTensorLength = product(outputFloat32TensorType.dimensions);
+
+    model.addOperand(outputFloat32TensorType);
+    model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+
+    model.identifyInputsAndOutputs([0], [3]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0,
+                    109.0, 110.0, 111.0, 112.0, 113.0, 114.0, 115.0, 116.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(outputTensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    let expectedData = new Float32Array(outputTensorLength);
+    expectedData.set([101.0, 102.0, 201.0, 202.0,
+                      103.0, 104.0, 203.0, 204.0,
+                      105.0, 106.0, 205.0, 206.0,
+                      107.0, 108.0, 207.0, 208.0,
+                      109.0, 110.0, 209.0, 210.0,
+                      111.0, 112.0, 211.0, 212.0,
+                      113.0, 114.0, 213.0, 214.0,
+                      115.0, 116.0, 215.0, 216.0]);
+
+    for (let i = 0; i < outputTensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], expectedData[i]));
+    }
+  });
+});

--- a/test/operations/max_pool_2d.js
+++ b/test/operations/max_pool_2d.js
@@ -1,0 +1,62 @@
+describe('Max_pool_2d Test', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it('check result', async function() {
+    let model = await nn.createModel(options);
+    const float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 1]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+    model.addOperand({type: nn.INT32});
+
+    // no padding on the left
+    model.setOperandValue(1, new Int32Array([0]));
+    // no padding on the right
+    model.setOperandValue(2, new Int32Array([0]));
+    // no padding on the top
+    model.setOperandValue(3, new Int32Array([0]));
+    // no padding on the bottom
+    model.setOperandValue(4, new Int32Array([0]));
+    // set the stride as 1 when walking through input in the ‘width’ dimension
+    model.setOperandValue(5, new Int32Array([1]));
+    // set the stride as 1 when walking through input in the ‘height’ dimension
+    model.setOperandValue(6, new Int32Array([1]));
+    // set the filter width as 1
+    model.setOperandValue(7, new Int32Array([1]));
+    // set the filter height as 1
+    model.setOperandValue(8, new Int32Array([1]));
+    model.setOperandValue(9, new Int32Array([nn.FUSED_NONE]));
+
+    model.addOperand(float32TensorType);
+    model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+
+    model.identifyInputsAndOutputs([0], [10]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([1.0, 2.0, 3.0, 4.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(tensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    for (let i = 0; i < tensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], inputData0[i]));
+    }
+  });
+});

--- a/test/operations/mul.js
+++ b/test/operations/mul.js
@@ -4,10 +4,10 @@ describe('Mul Test', function() {
   const nn = navigator.ml.getNeuralNetworkContext();
   const value0 = 0.4;
   const value1 = 0.5;
-    
+
   it('check result', async function() {
     let operandIndex = 0;
-    let model = await nn.createModel();
+    let model = await nn.createModel(options);
     const float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
     const tensorLength = product(float32TensorType.dimensions);
 
@@ -34,7 +34,7 @@ describe('Mul Test', function() {
     let compilation = await model.createCompilation();
 
     compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
-    
+
     await compilation.finish();
 
     let execution = await compilation.createExecution();

--- a/test/operations/reshape.js
+++ b/test/operations/reshape.js
@@ -1,0 +1,38 @@
+describe('Reshape Test', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+
+  it.skip('check result', async function() {
+    let model = await nn.createModel(options);
+
+    const float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions:[1, 4]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+    model.setOperandValue(1, new Int32Array([2, 2]));
+    model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2]});
+    model.addOperation(nn.RESHAPE, [0, 1], [2]);
+
+    model.identifyInputsAndOutputs([0], [2]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData = new Float32Array(tensorLength);
+    inputData.set([1.0, 2.0, 3.0, 4.0]);
+    execution.setInput(0, inputData);
+
+    let outputData = new Float32Array(tensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    for (let i = 0; i < tensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], inputData[i]));
+    }
+  });
+});

--- a/test/operations/reshape_neg1.js
+++ b/test/operations/reshape_neg1.js
@@ -1,0 +1,38 @@
+describe('Reshape Test using special value -1', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+
+  it.skip('check result', async function() {
+    let model = await nn.createModel(options);
+
+    const float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions:[1, 4]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+    model.setOperandValue(1, new Int32Array([2, -1]));
+    model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, -1]});
+    model.addOperation(nn.RESHAPE, [0, 1], [2]);
+
+    model.identifyInputsAndOutputs([0], [2]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData = new Float32Array(tensorLength);
+    inputData.set([1.0, 2.0, 3.0, 4.0]);
+    execution.setInput(0, inputData);
+
+    let outputData = new Float32Array(tensorLength);
+    execution.setOutput(0, outputData);
+    await execution.startCompute();
+
+    for (let i = 0; i < tensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], inputData[i]));
+    }
+  });
+});

--- a/test/operations/softmax.js
+++ b/test/operations/softmax.js
@@ -1,0 +1,39 @@
+describe('Softmax Test', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+  it.skip('check result', async function() {
+    let model = await nn.createModel(options);
+    const float32TensorType = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2]};
+    const tensorLength = product(float32TensorType.dimensions);
+
+    model.addOperand(float32TensorType);
+    model.addOperand({type: nn.FLOAT32});
+    model.setOperandValue(1, new Float32Array([1.0]));
+    model.addOperand(float32TensorType);
+    model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+
+    model.identifyInputsAndOutputs([0], [2]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(nn.PREFER_FAST_SINGLE_ANSWER);
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let inputData0 = new Float32Array(tensorLength);
+    inputData0.set([1.0, 1.0, 1.0, 1.0]);
+    execution.setInput(0, inputData0);
+
+    let outputData = new Float32Array(tensorLength);
+    execution.setOutput(0, outputData);
+
+    await execution.startCompute();
+    let expectedData = new Float32Array(tensorLength);
+    expectedData.set([0.5, 0.5, 0.5, 0.5]);
+
+    for (let i = 0; i < tensorLength; ++i) {
+      assert.isTrue(almostEqual(outputData[i], expectedData[i]));
+    }
+  });
+});

--- a/test/unit-test/test-Compilation.js
+++ b/test/unit-test/test-Compilation.js
@@ -13,7 +13,7 @@ describe('Compilation Test', function() {
 
   describe('#setPreference API', function() {
     it('check "setPreference" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -34,7 +34,7 @@ describe('Compilation Test', function() {
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -55,7 +55,7 @@ describe('Compilation Test', function() {
     });
 
     it('passing a parameter with value being in 0-2 is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -78,7 +78,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when passing a parameter with value being out of 0-2', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -101,7 +101,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when passing a parameter with \'string\' type value', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -124,7 +124,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when passing two parameters with values both being in 0-2', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -147,7 +147,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when attempting to reset the preference of the finished compilation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -174,7 +174,7 @@ describe('Compilation Test', function() {
 
   describe('#finish API', function() {
     it('check "finish" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -195,7 +195,7 @@ describe('Compilation Test', function() {
     });
 
     it('check return value is of "Promise<long>" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -222,7 +222,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when passing a parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -246,7 +246,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when calling this function more than once, the function must only be called once', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -277,7 +277,7 @@ describe('Compilation Test', function() {
 
   describe('#createExecution API', function() {
     it('check "createExecution" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -301,7 +301,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when passing a parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -327,7 +327,7 @@ describe('Compilation Test', function() {
     });
 
     it('raise error when calling this function with compilation not being finished', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);

--- a/test/unit-test/test-Execution.js
+++ b/test/unit-test/test-Execution.js
@@ -13,7 +13,7 @@ describe('Execution Test', function() {
 
   describe('#setInput API', function() {
     it('check "setInput" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -39,7 +39,7 @@ describe('Execution Test', function() {
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -67,7 +67,7 @@ describe('Execution Test', function() {
     });
 
     it.skip('raise error when the value being set to \'index\' is equal or greater than the size of inputs', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -97,7 +97,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when the input tensor type is \'TENSOR_FLOAT32\' and input data is not of \'Float32Arrary\' ', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -127,7 +127,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when the input tensor type is \'TENSOR_QUANT8_ASYMM\' and input data is not of \'Uint8Arrary\' ', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0};
         model.addOperand(op);
         model.addOperand(op);
@@ -157,7 +157,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing no parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -185,7 +185,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing one parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -213,7 +213,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing more than two parameters', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -243,7 +243,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing first parameter is of \'string\' type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -273,7 +273,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when setting invalid data to second parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -303,7 +303,7 @@ describe('Execution Test', function() {
 
   describe('#setOutput API', function() {
     it('check "setOutput" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -329,7 +329,7 @@ describe('Execution Test', function() {
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -356,7 +356,7 @@ describe('Execution Test', function() {
     });
 
     it.skip('raise error when the value being set to \'index\' is equal or greater than the size of outputs', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -386,7 +386,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when the output tensor type is \'TENSOR_FLOAT32\' and input data is not of \'Float32Arrary\' ', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -416,7 +416,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when the output tensor type is \'TENSOR_QUANT8_ASYMM\' and output data is not of \'Uint8Arrary\' ', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0};
         model.addOperand(op);
         model.addOperand(op);
@@ -446,7 +446,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing no parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -474,7 +474,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing one parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -502,7 +502,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing more than two parameters', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -532,7 +532,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing first parameter is of \'string\' type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -562,7 +562,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when setting invalid data to second parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -592,7 +592,7 @@ describe('Execution Test', function() {
 
   describe('#startCompute API', function() {
     it('check "startCompute" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -618,7 +618,7 @@ describe('Execution Test', function() {
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -648,7 +648,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when computing without inputs being ready', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -677,7 +677,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when computing without outputs being ready', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -708,7 +708,7 @@ describe('Execution Test', function() {
     });
 
     it('raise error when passing a parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);

--- a/test/unit-test/test-Model.js
+++ b/test/unit-test/test-Model.js
@@ -13,19 +13,19 @@ describe('Model Test', function() {
 
   describe('#addOperand API', function() {
     it('check "addOperand" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.isFunction(model.addOperand);
       });
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.equal(model.addOperand({type: nn.INT32}), undefined);
       });
     });
 
     it('passing a FLOAT32 scalar is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.FLOAT32});
         });
@@ -33,7 +33,7 @@ describe('Model Test', function() {
     });
 
     it('passing an INT32 scalar is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.INT32});
         });
@@ -41,7 +41,7 @@ describe('Model Test', function() {
     });
 
     it('passing an UINT32 scalar is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.UINT32});
         });
@@ -49,7 +49,7 @@ describe('Model Test', function() {
     });
 
     it('passing a TENSOR_FLOAT32 tensor having "dimensions" option is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         });
@@ -57,7 +57,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_FLOAT32 tensor not having "dimensions" option', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_FLOAT32});
         });
@@ -65,7 +65,7 @@ describe('Model Test', function() {
     });
 
     it('passing a TENSOR_INT32 tensor having "dimensions" option is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS});
         });
@@ -73,7 +73,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_INT32 tensor not having "dimensions" option', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_INT32});
         });
@@ -81,7 +81,7 @@ describe('Model Test', function() {
     });
 
     it('passing a TENSOR_QUANT8_ASYMM tensor having "dimensions", "scale" of non-negative and "zeroPoint" of 0 is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 0});
         });
@@ -89,7 +89,7 @@ describe('Model Test', function() {
     });
 
     it('passing a TENSOR_QUANT8_ASYMM tensor having "dimensions", "scale" of non-negative and "zeroPoint" of 100 is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 100});
         });
@@ -97,7 +97,7 @@ describe('Model Test', function() {
     });
 
     it('passing a TENSOR_QUANT8_ASYMM tensor having "dimensions", "scale" of non-negative and "zeroPoint" of 255 is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 0});
         });
@@ -105,7 +105,7 @@ describe('Model Test', function() {
     });
 
     it('passing a TENSOR_QUANT8_ASYMM tensor having "dimensions", "scale" of 0 and "zeroPoint" of [0-255] is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.doesNotThrow(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0, zeroPoint: 100});
         });
@@ -113,7 +113,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_QUANT8_ASYMM tensor having "dimensions", "scale" of non-negative and "zeroPoint" < 0', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: -1});
         });
@@ -121,7 +121,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_QUANT8_ASYMM tensor having "dimensions", "scale" of non-negative and "zeroPoint" > 255', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 256});
         });
@@ -129,7 +129,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_QUANT8_ASYMM tensor having "dimensions", "scale" of negative and "zeroPoint" of [0-255]', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, scale: -0.8, zeroPoint: 0});
         });
@@ -137,7 +137,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_QUANT8_ASYMM tensor not having "dimensions" options', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, scale: 0.8, zeroPoint: 0});
         });
@@ -145,7 +145,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_QUANT8_ASYMM tensor not having "scale" and "zeroPoint" options', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS});
         });
@@ -153,7 +153,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_QUANT8_ASYMM tensor not having "scale" options', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, zeroPoint: 0});
         });
@@ -161,7 +161,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing a TENSOR_QUANT8_ASYMM tensor not having "zeroPoint" options', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8});
         });
@@ -169,7 +169,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing no parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand();
         });
@@ -177,7 +177,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing parameter is not "OperandOptions" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand(123);
         });
@@ -185,7 +185,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing two scalars', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.INT32}, {type: nn.INT32});
         });
@@ -193,7 +193,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing two tensors', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperand({type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS},
                            {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS});
@@ -202,7 +202,7 @@ describe('Model Test', function() {
     });
 
     it.skip('raise error when attempting to add an operand into the finished model', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]};
         model.addOperand(op);
         model.addOperand(op);
@@ -225,20 +225,20 @@ describe('Model Test', function() {
 
   describe('#setOperandValue API', function() {
     it('check "setOperandValue" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.isFunction(model.setOperandValue);
       });
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.equal(model.setOperandValue(0, new Int32Array([0])), undefined);
       });
     });
 
     it('raise error when setting an Int8Array data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int8Array([0]));
@@ -247,7 +247,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8Array data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint8Array([0]));
@@ -256,7 +256,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8ClampedArray data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint8ClampedArray([0]));
@@ -265,7 +265,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int16Array data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int16Array([0]));
@@ -274,7 +274,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint16Array data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint16Array([0]));
@@ -283,7 +283,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int32Array data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int32Array([0]));
@@ -292,7 +292,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint32Array data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint32Array([0]));
@@ -301,7 +301,7 @@ describe('Model Test', function() {
     });
 
     it('setting a Float32Array data which length equals 1 for a FLOAT32 scalar is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.doesNotThrow(() => {
           model.setOperandValue(0, new Float32Array([0]));
@@ -310,7 +310,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float32Array data which length > 1 for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Float32Array([0, 0]));
@@ -319,7 +319,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float64Array data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         assert.throws(() => {
           model.setOperandValue(0, new Float64Array([0]));
@@ -328,7 +328,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a DataView data for a FLOAT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.FLOAT32});
         let buffer = new ArrayBuffer(1);
         let data = new DataView(buffer, 0);
@@ -339,7 +339,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int8Array data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int8Array([0]));
@@ -348,7 +348,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8Array data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint8Array([0]));
@@ -357,7 +357,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8ClampedArray data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint8ClampedArray([0]));
@@ -366,7 +366,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int16Array data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int16Array([0]));
@@ -375,7 +375,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint16Array data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint16Array([0]));
@@ -384,7 +384,7 @@ describe('Model Test', function() {
     });
 
     it('setting an Int32Array data which length equals 1 for an INT32 scalar is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.doesNotThrow(() => {
           model.setOperandValue(0, new Int32Array([0]));
@@ -393,7 +393,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int32Array data which length > 1 for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int32Array([0, 0]));
@@ -402,7 +402,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint32Array data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint32Array([0]));
@@ -411,7 +411,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float32Array data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Float32Array([0]));
@@ -420,7 +420,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float64Array data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         assert.throws(() => {
           model.setOperandValue(0, new Float64Array([0]));
@@ -429,7 +429,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a DataView data for an INT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.INT32});
         let buffer = new ArrayBuffer(1);
         let data = new DataView(buffer, 0);
@@ -440,7 +440,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int8Array data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int8Array([0]));
@@ -449,7 +449,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8Array data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint8Array([0]));
@@ -458,7 +458,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8ClampedArray data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint8ClampedArray([0]));
@@ -467,7 +467,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int16Array data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int16Array([0]));
@@ -476,7 +476,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint16Array data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint16Array([0]));
@@ -485,7 +485,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int32Array data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Int32Array([0]));
@@ -494,7 +494,7 @@ describe('Model Test', function() {
     });
 
     it('setting an Uint32Array data which length equals 1 for an UINT32 scalar is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.doesNotThrow(() => {
           model.setOperandValue(0, new Uint32Array([0]));
@@ -503,7 +503,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint32Array data which length > 1 for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Uint32Array([0, 0]));
@@ -512,7 +512,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float32Array data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Float32Array([0]));
@@ -521,7 +521,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float64Array data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         assert.throws(() => {
           model.setOperandValue(0, new Float64Array([0]));
@@ -530,7 +530,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a DataView data for an UINT32 scalar', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.UINT32});
         let buffer = new ArrayBuffer(1);
         let data = new DataView(buffer, 0);
@@ -541,7 +541,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int8Array data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Int8Array(product(op.dimensions));
@@ -553,7 +553,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8Array data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint8Array(product(op.dimensions));
@@ -565,7 +565,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8ClampedArray data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint8ClampedArray(product(op.dimensions));
@@ -577,7 +577,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int16Array data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Int16Array(product(op.dimensions));
@@ -589,7 +589,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint16Array data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint16Array(product(op.dimensions));
@@ -601,7 +601,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int32Array data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Int32Array(product(op.dimensions));
@@ -613,7 +613,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint32Array data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint32Array(product(op.dimensions));
@@ -625,7 +625,7 @@ describe('Model Test', function() {
     });
 
     it('setting a Float32Array data for a TENSOR_FLOAT32 tensor is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Float32Array(product(op.dimensions));
@@ -637,7 +637,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float64Array data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Float64Array(product(op.dimensions));
@@ -649,7 +649,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a DataView data for a TENSOR_FLOAT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let buffer = new ArrayBuffer(product(op.dimensions));
@@ -661,7 +661,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int8Array data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Int8Array(product(op.dimensions));
@@ -673,7 +673,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8Array data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint8Array(product(op.dimensions));
@@ -685,7 +685,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8ClampedArray data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint8ClampedArray(product(op.dimensions));
@@ -697,7 +697,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int16Array data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Int16Array(product(op.dimensions));
@@ -709,7 +709,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint16Array data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint16Array(product(op.dimensions));
@@ -721,7 +721,7 @@ describe('Model Test', function() {
     });
 
     it('setting an Int32Array data for a TENSOR_INT32 tensor is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Int32Array(product(op.dimensions));
@@ -733,7 +733,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint32Array data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Uint32Array(product(op.dimensions));
@@ -745,7 +745,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float32Array data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Float32Array(product(op.dimensions));
@@ -757,7 +757,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float64Array data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let data = new Float64Array(product(op.dimensions));
@@ -769,7 +769,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a DataView data for a TENSOR_INT32 tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         let buffer = new ArrayBuffer(product(op.dimensions));
@@ -781,7 +781,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int8Array data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Int8Array(product(op.dimensions));
@@ -793,7 +793,7 @@ describe('Model Test', function() {
     });
 
     it('setting an Uint8Array data for a TENSOR_QUANT8_ASYMM tensor is ok', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Uint8Array(product(op.dimensions));
@@ -805,7 +805,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint8ClampedArray data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Uint8ClampedArray(product(op.dimensions));
@@ -817,7 +817,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int16Array data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Int16Array(product(op.dimensions));
@@ -829,7 +829,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint16Array data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Uint16Array(product(op.dimensions));
@@ -841,7 +841,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Int32Array data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Int32Array(product(op.dimensions));
@@ -853,7 +853,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting an Uint32Array data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Uint32Array(product(op.dimensions));
@@ -865,7 +865,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float32Array data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Float32Array(product(op.dimensions));
@@ -877,7 +877,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a Float64Array data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let data = new Float64Array(product(op.dimensions));
@@ -889,7 +889,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when setting a DataView data for a TENSOR_QUANT8_ASYMM tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 1};
         model.addOperand(op);
         let buffer = new ArrayBuffer(product(op.dimensions));
@@ -901,7 +901,7 @@ describe('Model Test', function() {
     });
 
     it.skip('raise error when attempting to reset the value for an operand of the finished model', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]};
         model.addOperand(op);
         model.addOperand(op);
@@ -926,13 +926,13 @@ describe('Model Test', function() {
 
   describe('#addOperation API', function() {
     it('check "addOperation" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.isFunction(model.addOperation);
       });
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.equal(model.addOperation(nn.FLOOR, [0], [1]), undefined);
@@ -940,7 +940,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing no parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.addOperation();
         });
@@ -948,7 +948,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing only two parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
@@ -958,7 +958,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing more than 3 parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
@@ -968,7 +968,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing first parameter as undefined', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
@@ -978,7 +978,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing 2nd and 3rd parameters of \'number\' type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
@@ -988,7 +988,7 @@ describe('Model Test', function() {
     });
 
     it('first two input tensors (rank<=4) of compatible dimensions having identical TENSOR_FLOAT32 type as the output tensor with third input tensor of INT32 type having value of 0-3 are ok for "ADD" operation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]};
         model.addOperand(op);
         model.addOperand(op);
@@ -1005,7 +1005,7 @@ describe('Model Test', function() {
     });
 
     it('first two input tensors (rank<=4) of compatible dimensions having identical TENSOR_QUANT8_ASYMM type as the output tensor with third input tensor of INT32 type having value of 0-3 are ok for "ADD" operation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let input0Opertions = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 1, 2], scale: 0.8, zeroPoint: 0};
         model.addOperand(input0Opertions);
         let input1Opertions = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 1], scale: 0.5, zeroPoint: 1};
@@ -1024,7 +1024,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when one of first two input tensors doesn\'t have type of TENSOR_FLOAT32 or TENSOR_QUANT8_ASYMM for "ADD" operation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS});
         let input1Options = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(input1Options);
@@ -1041,7 +1041,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when first two input tensors of compatible dimensions don\'t have identical type(TENSOR_FLOAT32 or TENSOR_QUANT8_ASYMM) for "ADD" operation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let input0Options = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(input0Options);
         let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0.8, zeroPoint: 0};
@@ -1059,7 +1059,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when there is at least one of first two input tensors whose rank > 4 for "ADD" operation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let TENSOR_DIMENSIONS_RANK5 = [2, 2, 2, 2, 2];
         let optionsRank5 = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS_RANK5, scale: 0.8, zeroPoint: 0};
         model.addOperand(optionsRank5);
@@ -1078,7 +1078,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when first two input tensors whose rank are both <= 4 don\'t have compatible dimensions for "ADD" operation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let options0 = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 2, 2], scale: 0.8, zeroPoint: 0};
         model.addOperand(options0);
         let options1 = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 1], scale: 0.8, zeroPoint: 0};
@@ -1096,7 +1096,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when first two input tensors of compatible dimensions don\'t have identical type(TENSOR_FLOAT32 or TENSOR_QUANT8_ASYMM) as the output tensor for "ADD" operation', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let inputOptions = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(inputOptions);
         model.addOperand(inputOptions);
@@ -1113,8 +1113,2138 @@ describe('Model Test', function() {
       });
     });
 
+    it('raise error when the length of inputs is greater than 3 for "ADD" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(3, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.ADD, [0, 1, 2, 3], [4]);
+        });
+      });
+    });
+
+    it('raise error when the length of outputs is greater than 2 for "ADD" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand(op);
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.ADD, [0, 1, 2], [3, 4]);
+        });
+      });
+    });
+
+    it('"the length of inputs(explicit padding) being 10, 4-D tensor as input0, the type of intput1 to input8 being INT32 type, input9 also having INT32 type with value of 0-3, 4-D tensor as output" are ok for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(9, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+        });
+      });
+    });
+
+    it('"the length of inputs(implicit padding) being 7, 4-D tensor as input0, the type of intput1 to input5 being INT32 type, input6 also having INT32 type with value of 0-3, 4-D tensor as output" are ok for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 6 (not 7 or 10) for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(5, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5], [6]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 8 (not 7 or 10) for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 11 (not 7 or 10) for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(10, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11]);
+        });
+      });
+    });
+
+    it('raise error when input0 is of TENSOR_INT32 type (not TENSOR_FLOAT32 type or TENSOR_QUANT8_ASYMM type) for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is greater than 4 for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let RANK5_DIMENSIONS = [100, 100, 7, 7, 3];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is less than 4 for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let RANK3_DIMENSIONS = [100, 7, 7];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK3_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK3_DIMENSIONS});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when others inputs don\'t have identical INT32 type except input0 having TENSOR_FLOAT32 type (or TENSOR_QUANT8_ASYMM type) for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of output is greater than 4 tensor for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        let RANK5_DIMENSIONS = [100, 100, 7, 7, 3];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of output is less than 4 tensor for "AVERAGE_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        let RANK3_DIMENSIONS = [100, 7, 7];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSION3});
+        assert.throws(() => {
+          model.addOperation(nn.AVERAGE_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being 0, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0*(n-1), d1, d2, d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being -4, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0*(n-1), d1, d2, d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = -4;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being 1, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0, d1*(n-1), d2, d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = 1;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 4, 2, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being -3, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0, d1*(n-1), d2, d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = -3;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 4, 2, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being 2, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0, d1, d2*(n-1), d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = 2;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 4, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being -2, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0, d1, d2*(n-1), d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = -2;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 4, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being 3, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0, d1, d2, d3*(n-1)] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = 3;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 4]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being -1, others 0 to n-1 4-D inputs having identical TENSOR_FLOAT32 type and the same dimensions [d0, d1, d2, d3], the 4-D output having same TENSOR_FLOAT32 type and [d0, d1, d2, d3*(n-1)] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = -1;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 4]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the last INT32 type scale input being 0, others 0 to n-1 4-D inputs having identical TENSOR_QUANT8_ASYMM type with the same [d0, d1, d2, d3] dimensions, the same scale and zeroPoint, the 4-D output having same TENSOR_QUANT8_ASYMM type and [d0*(n-1), d1, d2, d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 2, 2, 2], scale: 1, zeroPoint: 1});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"the length of inputs being 2, 4-D input0 of TENSOR_FLOAT32 type with [d0, d1, d2, d3] dimensions, input1 of INT32 type being 0, the 4-D output having same type as input0 and [d0, d1, d2, d3] dimensions" are ok for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(1, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when 0 to n-1 4-D inputs not having identical TENSOR_FLOAT32 type but same dimensions for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when 0 to n-1 4-D inputs not having same dimensions but identical TENSOR_FLOAT32 type for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 2]});
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [3, 2, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is 4 not in (-4~3) with 0-n-1 inputs as 4-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        let axis = 4;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 4]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is -5 not in (-4~3) with 0-n-1 inputs as 4-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        let axis = -5;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is 3 not in (-3~2) with 0-n-1 inputs as 3-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2]});
+        model.addOperand({type: nn.INT32});
+        let axis = 3;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 4]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is -4 not in (-3~2) with 0-n-1 inputs as 3-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2]});
+        model.addOperand({type: nn.INT32});
+        let axis = -4;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is 2 not in (-2~1) with 0-n-1 inputs as 2-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2]});
+        model.addOperand({type: nn.INT32});
+        let axis = 2;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 4]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is -3 not in (-2~1) with 0-n-1 inputs as 2-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2]});
+        model.addOperand({type: nn.INT32});
+        let axis = -3;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is 1 not in (-1~0) with 0-n-1 inputs as 1-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2]});
+        model.addOperand({type: nn.INT32});
+        let axis = 1;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the last scale input is -2 not in (-1~0) with 0-n-1 inputs as 1-D tensors for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2]});
+        model.addOperand({type: nn.INT32});
+        let axis = -2;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when 0 to n-1 4-D inputs having identical TENSOR_QUANT8_ASYMM type with different scale for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0});
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 1, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 2, 2, 2], scale: 1, zeroPoint: 1});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when 0 to n-1 4-D inputs having identical TENSOR_QUANT8_ASYMM type with different zeroPoint for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0});
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: TENSOR_DIMENSIONS, scale: 0, zeroPoint: 1});
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 2, 2, 2], scale: 1, zeroPoint: 1});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the type of output is not identical with the type of 0 to n-1 inputs for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [4, 2, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the rank of 0 to n-1 inputs is greater than 4 for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let RANK5_DIMENSIONS = [2, 2, 2, 2, 2]
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [4, 2, 2, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the length of outputs is greater than 1 for "CONCATENATION" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand(op);
+        model.addOperand({type: nn.INT32});
+        let axis = 0;
+        model.setOperandValue(2, new Int32Array([axis]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2, 2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.CONCATENATION, [0, 1, 2], [3, 4]);
+        });
+      });
+    });
+
+    it('"the length of inputs (explicit padding) being 10, 4-D tensor as input0 of TENSOR_FLOAT32 type, 4-D tensor as input1 of TENSOR_FLOAT32 type, 1-D tensor as input2 of TENSOR_FLOAT32 type, the type of input3 to input8 being INT32 type, input9 also having INT32 type with value of 0-3, 4-D tensor as output having same type as input0 and input1" are ok for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(9, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+        });
+      });
+    });
+
+    it('"the length of inputs (implicit padding) being 7, 4-D tensor as input0 of TENSOR_FLOAT32 type, 4-D tensor as input1 of TENSOR_FLOAT32 type, 1-D tensor as input2 of TENSOR_FLOAT32 type, the type of input3 to input5 being INT32 type, input6 also having INT32 type with value of 0-3, 4-D tensor as output having same type as input0 and input1" are ok for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('"the length of inputs (implicit padding) being 7, 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, 1-D tensor as input2 of INT32 type having zeroPoint of 0 with bias_scale being equal to the product of input_scale and filter_scale, the type of input3 to input5 being INT32 type, input6 also having INT32 type with value of 0-3, 4-D tensor as output of same type as input0 and input1 with output_scale being greater than the product of input_scale and filter_scale" are ok for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [6, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.INT32, dimensions: [6], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale + 1.0;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+
+    it('raise when input0 and input1 are not 4-D tensors for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when input2 is not 1-D tensor for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(implicit padding) being 7, the types of input3 to input5 are not identical INT32 type for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(explicit padding) being 10 , the types of input3 to input8 are not identical INT32 type for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(implicit padding) is 6 (not 7 or 10) for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(5, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5], [6]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 8 (not 7 or 10) for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(explicit padding) is 11 (not 7 or 10) for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(10, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(implicit padding) being 7, the type of input6 is not INT32 type for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(6, new Float32Array([0.0]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(explicit padding) being 10, the type of input9 is not INT32 type for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(9, new Float32Array([0.0]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+        });
+      });
+    });
+
+    it('raise error when the type of output is not identical with the type of input0 and input1 for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the height of input0(its shape being [batches, height, width, depth_in]) is less than the filter_height of input1(its shape being [depth_out, filter_height, filter_width, depth_in]) for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 33, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 1, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the width of input0(its shape being [batches, height, width, depth_in]) is less than the filter_width of input1(its shape being [depth_out, filter_height, filter_width, depth_in]) for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 33, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 1, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the depth_in1 of input0(its shape being [batches, height, width, depth_in1]) is not equal to the depth_in2 of input1(its shape being [depth_out, filter_height, filter_width, depth_in2]) for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the batches1 of input0(its shape being [batches1, height, width, depth_in]) is not equal to the batches2 of output(its shape being [batches2, out_height, out_width, depth_out]) for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [101, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, 1-D tensor as input2 of INT32 type having zeroPoint of 0 with bias_scale being not equal to the product of input_scale and filter_scale for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [6, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale + 0.1;
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [6], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale + 1.0;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, 1-D tensor as input2 of INT32 type having bias_scale being equal to the product of input_scale and filter_scale with zeroPoint being greater than 0 for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [6, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [6], scale: bias_scale, zeroPoint: 1});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale + 1.0;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, output of same type as input0 with output_scale being equal to the product of input_scale and filter_scale with zeroPoint being greater than 0 for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [6, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [6], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, output of same type as input0 with output_scale being less than the product of input_scale and filter_scale for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [6, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [6], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale - 0.1;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the length of output is greater than 1 for "CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 5]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 5]});
+        assert.throws(() => {
+          model.addOperation(nn.CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7, 8]);
+        });
+      });
+    });
+
+    it('"the length of inputs(explicit padding) being 11, 4-D tensor as input0 of TENSOR_FLOAT32 type, 4-D tensor as input1 of TENSOR_FLOAT32 type, 1-D tensor as input2 of TENSOR_FLOAT32 type, the type of input3 to input9 being INT32 type, input10 also having INT32 type with value of 0-3, 4-D tensor as output having same type as input0 and input1" are ok for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let depth_in = 3;
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, depth_in]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        let depth_multiplier = 2;
+        model.setOperandValue(10, new Int32Array([depth_multiplier]));
+        model.setOperandValue(10, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let depth_out = depth_in * depth_multiplier;
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, depth_out]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11]);
+        });
+      });
+    });
+
+    it('"the length of inputs(implicit padding) being 8, 4-D tensor as input0 of TENSOR_FLOAT32 type, 4-D tensor as input1 of TENSOR_FLOAT32 type, 1-D tensor as input2 of TENSOR_FLOAT32 type, the type of input3 to input6 being INT32 type, input7 also having INT32 type with value of 0-3, 4-D tensor as output having same type as input0 and input1" are ok for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('"the length of inputs(implicit padding) being 8, 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, 1-D tensor as input2 of TENSOR_INT32 type having zeroPoint of 0 with bias_scale being equal to the product of input_scale and filter_scale, the type of input3 to input6 being INT32 type, input7 also having INT32 type with value of 0-3, 4-D tensor as output of same type as input0 and input1 with output_scale being greater than the product of input_scale and filter_scale" are ok for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [1], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        let output_scale = input_scale * filter_scale + 1.0;
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise when input0 and input1 are not 4-D tensors for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when input2 is not 1-D tensor for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [6, 1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(implicit padding) being 8, the types of input3 to input6 are not identical INT32 type for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(explicit padding) being 11, the types of input3 to input9 are not identical INT32 type for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(implicit padding) is 7 (not 8 or 11) for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 9 (not 8 or 11) for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(8, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8], [9]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(explicit padding) is 12 (not 8 or 11) for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(11, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], [12]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(implicit padding) being 8, the type of input7 is not INT32 type for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(7, new Float32Array([0.0]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(explicit padding) being 11, the type of input10 is not INT32 type for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(10, new Float32Array([0.0]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11]);
+        });
+      });
+    });
+
+    it('raise error when the type of output is not identical with the type of input0 and input1 for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [100, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the height of input0(its shape being [batches, height, width, depth_in]) is less than the filter_height of input1(its shape being [1, filter_height, filter_width, depth_out]) for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 33, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 1, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the width of input0(its shape being [batches, height, width, depth_in]) is less than the filter_width of input1(its shape being [1, filter_height, filter_width, depth_out]) for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 33, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 1, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the batches1 of input0(its shape being [batches1, height, width, depth_in]) is not equal to the batches2 of output(its shape being [batches2, out_height, out_width, depth_out]) for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [101, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the depth of filter input1(its shape being [depth, filter_height, filter_width, depth_out]) is not 1 for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [101, 28, 28, 6]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it.skip('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, 1-D tensor as input2 of TENSOR_INT32 type having zeroPoint of 0 with bias_scale being not equal to the product of input_scale and filter_scale for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale + 0.1;
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [1], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale + 1.0;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it.skip('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, 1-D tensor as input2 of TENSOR_INT32 type having bias_scale being equal to the product of input_scale and filter_scale with zeroPoint being greater than 0 for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [1], scale: bias_scale, zeroPoint: 1});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale + 1.0;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it.skip('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, output of same type as input0 with output_scale being equal to the product of input_scale and filter_scale with zeroPoint being greater than 0 for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.INT32, dimensions: [1], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        let output_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it.skip('raise error when 4-D tensor as input0 of TENSOR_QUANT8_ASYMM type having input_scale, 4-D tensor as input1 of TENSOR_QUANT8_ASYMM type having filter_scale, output of same type as input0 with output_scale being less than the product of input_scale and filter_scale for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 32, 32, 3], scale: input_scale, zeroPoint: 1});
+        let filter_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 5, 5, 3], scale: filter_scale, zeroPoint: 2});
+        let bias_scale = input_scale * filter_scale;
+        model.addOperand({type: nn.INT32, dimensions: [1], scale: bias_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        let output_scale = input_scale * filter_scale - 0.1;
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [100, 28, 28, 6], scale: output_scale, zeroPoint: 10});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the length of output is greater than 1 for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 5]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, 5]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8, 9]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(explicit padding) being 11, input0 having depth_in of shape([batches, height, width, depth_in]), and input9 specifying multiplier, the depth_out of output(its shape being [batches, out_height, out_width, depth_out]) is not equal to the product of the depth_in and the multiplier for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let depth_in = 3;
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, depth_in]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        let depth_multiplier = 2;
+        model.setOperandValue(6, new Int32Array([depth_multiplier]));
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        let depth_out = depth_in * depth_multiplier + 1;
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, depth_out]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs(implicit padding) being 8, input0 having depth_in of shape([batches, height, width, depth_in]), input6 specifying multiplier, the depth_out of output(its shape being [batches, out_height, out_width, depth_out]) is not equal to the product of the depth_in and multiplier for "DEPTHWISE_CONV_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let depth_in = 3;
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 32, 32, depth_in]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 5, 5, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        let depth_multiplier = 2;
+        model.setOperandValue(9, new Int32Array([depth_multiplier]));
+        model.setOperandValue(10, new Int32Array([nn.FUSED_NONE]));
+        let depth_out = depth_in * depth_multiplier + 1;
+        // Assume no padding and stride=1
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 28, 28, depth_out]});
+        assert.throws(() => {
+          model.addOperation(nn.DEPTHWISE_CONV_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11]);
+        });
+      });
+    });
+
+    it('"the length of inputs(explicit padding) being 10, 4-D tensor as input0, the type of intput1 to input8 being INT32 type, input9 also having INT32 type with value of 0-3, 4-D tensor as output" are ok for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(9, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [10]);
+        });
+      });
+    });
+
+    it('"the length of inputs(implicit padding) being 7, 4-D tensor as input0, the type of intput1 to input5 being INT32 type, input6 also having INT32 type with value of 0-3, 4-D tensor as output" are ok for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 6 (not 7 or 10) for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(5, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5], [6]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 8 (not 7 or 10) for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(7, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7], [8]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is 11 (not 7 or 10) for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(10, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11]);
+        });
+      });
+    });
+
+    it('raise error when input0 is of TENSOR_INT32 type (not TENSOR_FLOAT32 type or TENSOR_QUANT8_ASYMM type) for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is greater than 4 for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let RANK5_DIMENSIONS = [100, 100, 7, 7, 3];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is less than 4 for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let RANK3_DIMENSIONS = [100, 7, 7];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK3_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK3_DIMENSIONS});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when others inputs don\'t have identical INT32 type except input0 having TENSOR_FLOAT32 type (or TENSOR_QUANT8_ASYMM type) for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of output is greater than 4 tensor for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        let RANK5_DIMENSIONS = [100, 100, 7, 7, 3];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('raise error when the rank of output is less than 4 tensor for "MAX_POOL_2D" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [100, 7, 7, 3]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(6, new Int32Array([nn.FUSED_NONE]));
+        let RANK3_DIMENSIONS = [100, 7, 7];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSION3});
+        assert.throws(() => {
+          model.addOperation(nn.MAX_POOL_2D, [0, 1, 2, 3, 4, 5, 6], [7]);
+        });
+      });
+    });
+
+    it('"first two input tensors (rank <= 4) of compatible dimensions having identical TENSOR_FLOAT32 type as the output tensor, input2 tensor of INT32 type having value of 0-3" are ok for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 1]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('"first two input tensors (rank <= 4) of compatible dimensions having identical TENSOR_QUANT8_ASYMM type, input2 tensor of INT32 type having value of 0-3, the output tensor also having TENSOR_QUANT8_ASYMM type with its scale is greater than the product by the scale of input0 and the scale of input1" are ok for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input0_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 1], scale: input0_scale, zeroPoint: 0});
+        let input1_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 1, 2], scale: input1_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        let output_scale = input0_scale * input1_scale + 0.1;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 2], scale: output_scale, zeroPoint: 0});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when there is at least one of first two input tensors whose rank is greater than 4 for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let RANK5_DIMENSIONS =  [2, 2, 2, 2, 2];
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 2, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the type of input0 is different from the type of input1 for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 1]});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [4, 1, 2]});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the dimension of input0 is not compatible with the dimension of input1 for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 1]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 2, 2]});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the type of output is different from the type of input0 and input1 for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 1]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [5, 4, 3, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the scale of output tensor(being of TENSOR_QUANT8_ASYMM type) is equal to the product of the input0 scale and the input1 scale for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input0_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 1], scale: input0_scale, zeroPoint: 0});
+        let input1_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 1, 2], scale: input1_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        let output_scale = input0_scale * input1_scale;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 2], scale: output_scale, zeroPoint: 0});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the scale of output tensor(being of TENSOR_QUANT8_ASYMM type) is less than the product of the input0 scale and the input1 scale for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let input0_scale = 0.5;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 1], scale: input0_scale, zeroPoint: 0});
+        let input1_scale = 0.2;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [4, 1, 2], scale: input1_scale, zeroPoint: 0});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        let output_scale = input0_scale * input1_scale - 0.1;
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [5, 4, 3, 2], scale: output_scale, zeroPoint: 0});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is greater than 3 for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 1]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]});
+        model.addOperand({type: nn.INT32});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(3, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2, 3], [4]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is less than 3 for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 1]});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(1, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the length of outputs is greater than 1 for "MUL" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 1]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 1, 2]});
+        model.addOperand({type: nn.INT32});
+        model.setOperandValue(2, new Int32Array([nn.FUSED_NONE]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 2]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [5, 4, 3, 2]});
+        assert.throws(() => {
+          model.addOperation(nn.MUL, [0, 1, 2], [3, 4]);
+        });
+      });
+    });
+
+    it('"input0 as a tensor (rank <= 4) of TENSOR_FLOAT32 type, input1 as a 1-D tensor of TENSOR_INT32 type" are ok for "RESHAPE" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 4]});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+        model.setOperandValue(1, new Int32Array([2, 2]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 2]});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.RESHAPE, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('"input0 as a tensor (rank <= 4) of TENSOR_QUANT8_ASYMM type, input1 as a 1-D tensor of TENSOR_INT32 type" are ok for "RESHAPE" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 4], scale: 0, zeroPoint: 0});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+        model.setOperandValue(1, new Int32Array([2, 2]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [2, 2], scale: 0, zeroPoint: 0});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.RESHAPE, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is greater than 4 for "RESHAPE" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let RANK5_DIMENSIONS = [2, 2, 2, 2, 2]
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: RANK5_DIMENSIONS});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+        model.setOperandValue(1, new Int32Array([4, 8]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [4, 8]});
+        assert.throws(() => {
+          model.addOperation(nn.RESHAPE, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the number of elements in output tensor is not equal the number of elements in the input tensor for "RESHAPE" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 4]});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+        model.setOperandValue(1, new Int32Array([2, 3]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.RESHAPE, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is greater than 2 for "RESHAPE" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 4]});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+        model.setOperandValue(1, new Int32Array([2, 3]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.RESHAPE, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the length of outputs is greater than 1 for "RESHAPE" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [1, 4]});
+        model.addOperand({type: nn.TENSOR_INT32, dimensions: [2]});
+        model.setOperandValue(1, new Int32Array([2, 3]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 3]});
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 3]});
+        assert.throws(() => {
+          model.addOperation(nn.RESHAPE, [0, 1], [2, 3]);
+        });
+      });
+    });
+
+    it('"input0 as a 2-D tensor of TENSOR_FLOAT32 type, input1 as a scale of FLOAT32 type (its value being positive) and output tensor of same shape as input0" are ok for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [1, 4]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand(op);
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('"input0 as a 4-D tensor of TENSOR_FLOAT32 type, input1 as a scale of FLOAT32 type (its value being positive) and output tensor of same shape as input0" are ok for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand(op);
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('"input0 as a 2-D tensor of TENSOR_QUANT8_ASYMM type, input1 as a scale of FLOAT32 type (its value being positive), output tensor of same shape as input0 and scale as 1.f / 256 and the zeroPoint as 0" are ok for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 4], scale: 0, zeroPoint: 0});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, dimensions: [1, 4], scale: 1.0 / 256, zeroPoint: 0});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('"input0 as a 4-D tensor of TENSOR_QUANT8_ASYMM type, input1 as a scale of FLOAT32 type (its value being positive), output tensor of same shape as input0 and scale as 1.f / 256 and the zeroPoint as 0" are ok for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, TENSOR_DIMENSIONS, scale: 1.0 / 256, zeroPoint: 0});
+        assert.doesNotThrow(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when input1 as a scale of FLOAT32 type (its value being 0.0) for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [1, 4]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.0]));
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when input1 as a scale of FLOAT32 type (its value being negative) for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [1, 4]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([-1.0]));
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when output tensor is not of same shape as input0 for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [1, 4]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: [2, 1]});
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the scale of TENSOR_QUANT8_ASYMM type output tensor is not 1.f / 256 for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, TENSOR_DIMENSIONS, scale: 1.0, zeroPoint: 0});
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the zeroPoint of TENSOR_QUANT8_ASYMM type output tensor is not 0 for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, TENSOR_DIMENSIONS, scale: 0, zeroPoint: 0});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand({type: nn.TENSOR_QUANT8_ASYMM, TENSOR_DIMENSIONS, scale: 1.0 / 256, zeroPoint: 1});
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is 1 (not 2 or 4) for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [2]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is 3 (not 2 or 4) for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the rank of input0 is 5 (not 2 or 4) for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2, 2, 2, 2]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2]);
+        });
+      });
+    });
+
+    it('raise error when the length of inputs is greater than 2 for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1, 2], [3]);
+        });
+      });
+    });
+
+    it('raise error when the length of outputs is greater than 1 for "SOFTMAX" operation', function() {
+      return nn.createModel(options).then((model)=>{
+        let op = {type: nn.TENSOR_FLOAT32, dimensions: [2, 2]};
+        model.addOperand(op);
+        model.addOperand({type: nn.FLOAT32});
+        model.setOperandValue(1, new Float32Array([0.000001]));
+        model.addOperand(op);
+        model.addOperand(op);
+        assert.throws(() => {
+          model.addOperation(nn.SOFTMAX, [0, 1], [2, 3]);
+        });
+      });
+    });
+
+
     it.skip('raise error when attempting to reset the operation of the finished model', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -1137,13 +3267,13 @@ describe('Model Test', function() {
 
   describe('#identifyInputsAndOutputs API', function() {
     it('check "identifyInputsAndOutputs" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.isFunction(model.identifyInputsAndOutputs);
       });
     });
 
     it('check return value is of "void" type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.equal(model.identifyInputsAndOutputs([0], [1]), undefined);
@@ -1151,7 +3281,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when letting input tensor be output tensor', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
           model.identifyInputsAndOutputs([0], [0]);
@@ -1160,7 +3290,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when target input(s) wasn\'t(or weren\'t) previously added', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
           model.identifyInputsAndOutputs([1], [0]);
@@ -1169,7 +3299,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when target output(s) wasn\'t(or weren\'t) previously added', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
           model.identifyInputsAndOutputs([0], [1]);
@@ -1178,7 +3308,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing no parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.throws(() => {
           model.identifyInputsAndOutputs();
         });
@@ -1186,7 +3316,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing only one parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
           model.identifyInputsAndOutputs([0]);
@@ -1195,7 +3325,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing more than two parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
@@ -1205,7 +3335,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when passing two parameter of \'number\' type', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         model.addOperand({type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS});
         assert.throws(() => {
@@ -1215,7 +3345,7 @@ describe('Model Test', function() {
     });
 
     it.skip('raise error when attempting to modify inputs/outputs of the finished model', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -1238,13 +3368,13 @@ describe('Model Test', function() {
 
   describe('#finish API', function() {
     it('check "finish" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.isFunction(model.finish);
       });
     });
 
     it('raise error when passing a parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -1263,7 +3393,7 @@ describe('Model Test', function() {
     });
 
     it('check return value is of "Promise<long>" type after being called successfully', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -1284,7 +3414,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when calling this function more than once, the function must only be called once', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -1308,13 +3438,13 @@ describe('Model Test', function() {
 
   describe('#createCompilation API', function() {
     it('check "createCompilation" is a function', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         assert.isFunction(model.createCompilation);
       });
     });
 
     it('raise error when passing a parameter', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -1335,7 +3465,7 @@ describe('Model Test', function() {
     });
 
     it('raise error when calling this function with model not being finished', function() {
-      return nn.createModel().then((model)=>{
+      return nn.createModel(options).then((model)=>{
         let op = {type: nn.TENSOR_FLOAT32, dimensions: TENSOR_DIMENSIONS};
         model.addOperand(op);
         model.addOperand(op);
@@ -1354,4 +3484,3 @@ describe('Model Test', function() {
     });
   });
 });
-

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,5 @@
+let options = {};
+
 function product(array) {
   return array.reduce((accumulator, currentValue) => accumulator * currentValue);
 }
@@ -10,5 +12,17 @@ function almostEqual(a, b) {
   } else {
     console.warn(`a(${a}) b(${b}) delta(${delta})`);
     return false;
+  }
+}
+
+function setOptions() {
+  // visit URL(http://domain-name/test/index.html?backend=webgl2) to test Unit Tests by WebGL2 backend
+  var parameterStr = window.location.search.substr(1);
+  var reg = new RegExp("(^|&)backend=([^&]*)(&|$)", "i");
+  var r = parameterStr.match(reg);
+  if (r != null && unescape(r[2]) == "webgl2") {
+    options = {
+      "useWebGL2": true
+    };
   }
 }


### PR DESCRIPTION
Accoring to [ANEURALNETWORKS_DEPTHWISE_CONV_2D](https://developer.android.com/ndk/reference/group/neural-networks#group___neural_networks_1ggaabbe492c60331b13038e39d4207940e0a2b49a44b7ebba243fad01556c1f0392e) explanation in Android NN API document, I updated 
> Inputs (explicit padding):

to be

> Inputs (**implicit** padding):

for the comments of **DEPTHWISE_CONV_2D** in src/nn/Enums.js

Referring to **concatenation** and **reshape** methods of tensorflow in python version, I wrote some tests  in the test/operations folder for concatenation and reshape operations.

Use **window.onload** event to prepare options for createModel function, then we cloud run unit tests
using Web ML Polyfill API with **WebGL2 backend** by visit such url:
> http://\<domain-name\>/test/index.html?backend=webgl2

@huningxin PTAL, thanks.
