### PR TITLE
Fix case-sensitive variable name issue in MobileNet.js

### DIFF
--- a/examples/mobilenet/MobileNet.js
+++ b/examples/mobilenet/MobileNet.js
@@ -190,7 +190,7 @@ class MobileNet {
           opType = this._nn.RESHAPE;
         } break;
         default: {
-          throw new Error(`operator type ${opcode} is not supported.`);
+          throw new Error(`operator type ${opCode} is not supported.`);
         }
       }
       this._model.addOperation(opType, inputs, outputs);


### PR DESCRIPTION
Signed-off-by: Belem Zhang <belem.zhang@intel.com>

Fix https://github.com/intel/webml-polyfill/issues/101 

MobileNet.js: 
Line 126:      let opCode = this._tfModel.operatorCodes(operator.opcodeIndex()).builtinCode();
Line 193:           throw new Error(`operator type ${opcode} is not supported.`);

The ${opcode} causes following error in throw new Error() statement:

Uncaught (in promise) ReferenceError: **opcode** is not defined
    at MobileNet._addOpsAndParams (MobileNet.js:193)

Update variable name from "opcode" to 'opCode' declared in Line 126 can fix this issue.



