### PR TITLE
[WebGL2][PoseNet] Support scale factor = 1

### DIFF
--- a/src/nn/webgl2/Model.js
+++ b/src/nn/webgl2/Model.js
@@ -86,7 +86,7 @@ export default class Model {
         }
         this._execute(tmpInputs, tmpOutputs, i);
         for (let j = 0; j < outputs.size; ++j) {
-          tmpBuffer[j].push(...(tmpOutputs.get(j).buffer));
+          tmpOutputs.get(j).buffer.forEach(a => tmpBuffer[j].push(a));
         }
       }
       for (let j = 0; j < outputs.size; ++j) {

--- a/src/nn/webgl2/Tensor.js
+++ b/src/nn/webgl2/Tensor.js
@@ -117,9 +117,6 @@ export default class Tensor {
 
     const shape = this.textureSliceShape;
     const numSlices = Math.ceil(this.textureShape[0] / webgl2.MAX_TEXTURE_SIZE);
-    if (numSlices > webgl2.MAX_TEXTURE_IMAGE_UNITS) {
-      throw new Error(`[Tensor] numSlices ${numSlices} > MAX_TEXTURE_IMAGE_UNITS ${webgl2.MAX_TEXTURE_IMAGE_UNITS}`);
-    }
     let offset = 0;
 
     for (let k = 0; k < numSlices; k++) {


### PR DESCRIPTION
Fix #142 #214 
_MAX_TEXTURE_IMAGE_UNITS_ is not used in Keras.js, let's just remove it.