### PR TITLE
[WebGL2] Correct the output range of RELU1 to [-1, 1]

### DIFF
--- a/src/nn/webgl2/webgl/fragmentShader/activation/RELU1.js
+++ b/src/nn/webgl2/webgl/fragmentShader/activation/RELU1.js
@@ -8,5 +8,5 @@ out vec4 outColor;
 
 void main() {
   vec4 v = texture(x, vec2(outTex.x, outTex.y));
-  outColor = min(max(v, 0.0), 1.0);
+  outColor = min(max(v, -1.0), 1.0);
 }`;

--- a/src/nn/webgl2/webgl/fragmentShader/activation/fuse.js
+++ b/src/nn/webgl2/webgl/fragmentShader/activation/fuse.js
@@ -1,6 +1,6 @@
 export const fuseShaderSource = {
     "RELU": 'sum = max(sum, 0.0);',
-    "RELU1": 'sum = min(max(sum, 0.0), 1.0);',
+    "RELU1": 'sum = min(max(sum, -1.0), 1.0);',
     "RELU6": 'sum = min(max(sum, 0.0), 6.0);',
     "NONE": ''
 }


### PR DESCRIPTION
passes: _**91**_  failures: _**14**_  duration: _**2.67**_ s
 => passes: _**101**_  failures: _**4**_  duration: _**2.82**_ s

fix #272 
