### PR TITLE
[example] Fix typo issue for resnet model files name

### DIFF
--- a/examples/image_classification/model/README.md
+++ b/examples/image_classification/model/README.md
@@ -23,8 +23,8 @@ inception_resnet_v2.tflite
 
 squeezenet1.1.onnx
 mobilenetv2-1.0.onnx
-resnet18v1.onnx
-resnet18v2.onnx
+resnet50v1.onnx
+resnet50v2.onnx
 inceptionv2.onnx
 densenet121.onnx
 ```


### PR DESCRIPTION
Base on the souce code below, the model files name should be resnet50v1 and resnet50v2 rather than 18.

```
const resnet_v1_onnx = {
  modelName: 'ResNet50 v1(Onnx)',
  modelFile: './model/resnet50v1.onnx',
  ...
};
const resnet_v2_onnx = {
  modelName: 'ResNet50 v2(Onnx)',
  modelFile: './model/resnet50v2.onnx',
  ...
};
```
@pinzhenx @Wenzhao-Xiang  please review.