### PR TITLE
upgrade webpack and dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ MacOS | Linux | Windows
 $ npm install
 ```
 
+### Start
+
+```sh
+$ npm start
+```
+
+Start an HTTPS server:
+```sh
+$ HTTPS=true npm start
+```
+
 ### Build
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "watch": "webpack --watch",
-    "start": "npm run build && http-server .",
+    "start": "webpack-dev-server --open",
     "build": "webpack",
     "build-wasm": "node build.js --build-wasm",
     "test": "node test-ci.js"
@@ -35,8 +35,11 @@
     "ndarray": "^1.0.18",
     "ndarray-ops": "^1.2.2",
     "ndarray-squeeze": "^1.0.2",
+    "portfinder": "^1.0.20",
     "selenium-webdriver": "^3.1.0",
-    "webpack": "^3.5.5",
+    "webpack": "^4.26.0",
+    "webpack-cli": "^3.1.2",
+    "webpack-dev-server": "^3.1.10",
     "npmlog": "^4.1.2",
     "globby": "^8.0.1",
     "rimraf": "^2.6.2",


### PR DESCRIPTION
Fix #477
- Upgrade Webpack from 3 to 4
- Replace `http-server` with `webpack-dev-server`
- Support hot reloading
- Support HTTPS
- Enable source map


