### PR TITLE
[package.json] Fix #495 license with standardized short identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "keywords": [],
   "author": "ningxin.hu@intel.com",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/intel/webml-polyfill/issues"
   },


### PR DESCRIPTION
SPDX License List can be found at https://spdx.org/licenses/