### PR TITLE
Remove ssd_mobilenet path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ examples/**/*.tflite
 examples/**/*.onnx
 src/nn/wasm/src/build
 .DS_Store
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,5 @@ node_modules/
 dist/
 examples/**/*.tflite
 examples/**/*.onnx
-examples/ssd_mobilenet/model/
-!examples/ssd_mobilenet/model/README.md
 src/nn/wasm/src/build
 .DS_Store


### PR DESCRIPTION
The "ssd_mobilenet" path does not exist and the models filter rule has been covered by:

```
examples/**/*.tflite
examples/**/*.onnx
```