### PR TITLE
[Example] Support atrous convolution in PoseNet example

### DIFF
--- a/examples/posenet/camera.js
+++ b/examples/posenet/camera.js
@@ -53,6 +53,11 @@ model.onFinishChange((model) => {
   initModel();
 });
 
+dilated.onFinishChange((dilated) => {
+  guiState.dilated = dilated;
+  initModel();
+});
+
 outputStride.onFinishChange((outputStride) => {
   guiState.outputStride = parseInt(outputStride);
   initModel();

--- a/examples/posenet/camera.js
+++ b/examples/posenet/camera.js
@@ -53,8 +53,8 @@ model.onFinishChange((model) => {
   initModel();
 });
 
-dilated.onFinishChange((dilated) => {
-  guiState.dilated = dilated;
+use_atrous_conv.onFinishChange((use_atrous_conv) => {
+  guiState.use_atrous_conv = use_atrous_conv;
   initModel();
 });
 

--- a/examples/posenet/gui.js
+++ b/examples/posenet/gui.js
@@ -2,6 +2,7 @@ let guiState;
 guiState = {
   algorithm: 'multi-pose',
   model: 1.01,
+  dilated: false, 
   outputStride: 16,
   scaleFactor: 0.5,
   scoreThreshold: 0.5,
@@ -15,6 +16,7 @@ guiState = {
 const gui = new dat.GUI({width: 300});
 gui.domElement.id = 'gui';
 const model = gui.add(guiState, 'model', [0.50, 0.75, 1.00, 1.01]);
+const dilated = gui.add(guiState, 'dilated');
 const outputStride = gui.add(guiState, 'outputStride', [8, 16, 32]);
 const scaleFactor = gui.add(guiState, 'scaleFactor', [0.25, 0.5, 0.75, 1.00]).listen();
 const scoreThreshold = gui.add(guiState, 'scoreThreshold', 0.0, 1.0).listen();

--- a/examples/posenet/gui.js
+++ b/examples/posenet/gui.js
@@ -2,7 +2,7 @@ let guiState;
 guiState = {
   algorithm: 'multi-pose',
   model: 1.01,
-  dilated: false, 
+  use_atrous_conv: false, 
   outputStride: 16,
   scaleFactor: 0.5,
   scoreThreshold: 0.5,
@@ -16,7 +16,7 @@ guiState = {
 const gui = new dat.GUI({width: 300});
 gui.domElement.id = 'gui';
 const model = gui.add(guiState, 'model', [0.50, 0.75, 1.00, 1.01]);
-const dilated = gui.add(guiState, 'dilated');
+const use_atrous_conv = gui.add(guiState, 'use_atrous_conv');
 const outputStride = gui.add(guiState, 'outputStride', [8, 16, 32]);
 const scaleFactor = gui.add(guiState, 'scaleFactor', [0.25, 0.5, 0.75, 1.00]).listen();
 const scoreThreshold = gui.add(guiState, 'scoreThreshold', 0.0, 1.0).listen();

--- a/examples/posenet/main.js
+++ b/examples/posenet/main.js
@@ -235,8 +235,8 @@ model.onFinishChange((model) => {
   initModel();
 });
 
-dilated.onFinishChange((dilated) => {
-  guiState.dilated = dilated;
+use_atrous_conv.onFinishChange((use_atrous_conv) => {
+  guiState.use_atrous_conv = use_atrous_conv;
   initModel();
 });
 

--- a/examples/posenet/main.js
+++ b/examples/posenet/main.js
@@ -235,6 +235,11 @@ model.onFinishChange((model) => {
   initModel();
 });
 
+dilated.onFinishChange((dilated) => {
+  guiState.dilated = dilated;
+  initModel();
+});
+
 outputStride.onFinishChange((outputStride) => {
   guiState.outputStride = parseInt(outputStride);
   initModel();

--- a/examples/posenet/src/PoseNet.js
+++ b/examples/posenet/src/PoseNet.js
@@ -1,5 +1,5 @@
 class PoseNet{
-  constructor(modelArch, version, dilated, outputStride, inputShape, type, cacheMap, backend, prefer) {
+  constructor(modelArch, version, use_atrous_conv, outputStride, inputShape, type, cacheMap, backend, prefer) {
     this._modelArch = modelArch;
     this._model = null;
     this._compilation;
@@ -7,7 +7,7 @@ class PoseNet{
     this._tensorIds = [];
     this._operandIndex = 0;
     this._version = version;
-    this._dilated = dilated;
+    this._use_atrous_conv = use_atrous_conv;
     this._outputStride = outputStride;
     this._inputShape = inputShape;
     this._outputLayer = [];
@@ -147,7 +147,7 @@ class PoseNet{
           outputLayerIndex++;
         }
         const data = await getDimensionData("separableConv", this._version, i, manifest, this._cacheMap);
-        if (this._dilated || this._modelArch[i].rate === 1) { 
+        if (this._use_atrous_conv || this._modelArch[i].rate === 1) { 
           dimensionWeights.push(reshape(data.shapeWeights[0]));
           dimensionWeights.push(reshape(data.shapeWeights[1]));
           weights.push(new Float32Array(transposeWeights(data.weights[0], data.shapeWeights[0])));
@@ -212,7 +212,7 @@ class PoseNet{
             const multiplier = 1;
             let outputs = this._outputLayer[outputLayerIndex];
             inputs.push(this._addScalarInt32(paddingCode));
-            if (this._dilated && this._modelArch[i].rate !== 1) {
+            if (this._use_atrous_conv && this._modelArch[i].rate !== 1) {
               inputs.push(this._addScalarInt32(this._modelArch[i].rate));
               inputs.push(this._addScalarInt32(this._modelArch[i].rate));
               opType = this._nn.ATROUS_DEPTHWISE_CONV_2D;

--- a/examples/posenet/utils.js
+++ b/examples/posenet/utils.js
@@ -82,7 +82,7 @@ class Utils{
     this.model;
     // single input
     this._version;
-    this._dilated;
+    this._use_atrous_conv;   // If set to true, will use ATROUS_DEPTHWISE_CONV2D in this model
     this._outputStride;
     this._minScore;
     this._scaleFactor;
@@ -102,7 +102,7 @@ class Utils{
     this.initialized = false;
     // single input
     this._version = guiState.model;
-    this._dilated = guiState.dilated;
+    this._use_atrous_conv = guiState.use_atrous_conv;
     this._outputStride = guiState.outputStride;
     this._minScore = guiState.scoreThreshold;
     this._scaleFactor = guiState.scaleFactor;
@@ -133,7 +133,7 @@ class Utils{
     this.offsetTensor = new Float32Array(this.OFFSET_TENSOR_SIZE);
     this.displacementFwd = new Float32Array(this.DISPLACEMENT_FWD_SIZE);
     this.displacementBwd = new Float32Array(this.DISPLACEMENT_BWD_SIZE);
-    this.model = new PoseNet(this.modelArch, Number(this._version), this._dilated, Number(this._outputStride),
+    this.model = new PoseNet(this.modelArch, Number(this._version), this._use_atrous_conv, Number(this._outputStride),
                              this.scaleInputSize, this._type, this._cacheMap, backend, prefer);
     let start = performance.now();
     result = await this.model.createCompiledModel();

--- a/examples/posenet/utils.js
+++ b/examples/posenet/utils.js
@@ -82,6 +82,7 @@ class Utils{
     this.model;
     // single input
     this._version;
+    this._dilated;
     this._outputStride;
     this._minScore;
     this._scaleFactor;
@@ -101,6 +102,7 @@ class Utils{
     this.initialized = false;
     // single input
     this._version = guiState.model;
+    this._dilated = guiState.dilated;
     this._outputStride = guiState.outputStride;
     this._minScore = guiState.scoreThreshold;
     this._scaleFactor = guiState.scaleFactor;
@@ -131,11 +133,11 @@ class Utils{
     this.offsetTensor = new Float32Array(this.OFFSET_TENSOR_SIZE);
     this.displacementFwd = new Float32Array(this.DISPLACEMENT_FWD_SIZE);
     this.displacementBwd = new Float32Array(this.DISPLACEMENT_BWD_SIZE);
-    this.model = new PoseNet(this.modelArch, Number(this._version), Number(this._outputStride),
+    this.model = new PoseNet(this.modelArch, Number(this._version), this._dilated, Number(this._outputStride),
                              this.scaleInputSize, this._type, this._cacheMap, backend, prefer);
     let start = performance.now();
     result = await this.model.createCompiledModel();
-    console.log('compilation result: ${result}');
+    console.log(`compilation result: ${result}`);
     let elapsed = performance.now() - start;
     console.log(`Compilation time: ${elapsed.toFixed(2)} ms`);
     this.initialized = true;


### PR DESCRIPTION
**No ATROUS_DEPTHWISE_CONV2D:**
![image](https://user-images.githubusercontent.com/40754037/51368229-7316e480-1b29-11e9-9c4d-872827538bc0.png)
**ATROUS_DEPTHWISE_CONV2D:**
![image](https://user-images.githubusercontent.com/40754037/51368260-9fcafc00-1b29-11e9-9e82-4b72160973d6.png)

Performance: 
Only 20~30 ms speed up in WASM, and almost no speed up in WebGL.