### PR TITLE
[Example] delete integrity and crossorigin for all examples

### DIFF
--- a/examples/deeplab/camera.html
+++ b/examples/deeplab/camera.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Segmentation Camera Demo</title>
-    <link rel="stylesheet" href="../third_party/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="../third_party/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
@@ -137,11 +137,11 @@
       </div>
 
     </div>
-    <script src="../third_party/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-    <script src="../third_party/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="../third_party/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script src="../third_party/jquery-3.3.1.min.js"></script>
+    <script src="../third_party/popper.min.js"></script>
+    <script src="../third_party/bootstrap.min.js"></script>
     <script src="../third_party/stats.min.js"></script>
-    <script src="../third_party/iro.min.js" integrity="sha384-4wKYljBiUCSo5tJCQfnFKWf8TAHJxejy8pV2PItmsr0CBWu45fsMtEndOsWNynmn" crossorigin="anonymous"></script>
+    <script src="../third_party/iro.min.js"></script>
     <script src="../../dist/webml-polyfill.js"></script>
     <script src="../util/base.js"></script>
     <script src="../util/tflite/flatbuffers/js/flatbuffers.js"></script>

--- a/examples/deeplab/index.html
+++ b/examples/deeplab/index.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>Segmentation Demo</title>
-    <link rel="stylesheet" href="../third_party/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="../third_party/bootstrap.min.css">
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
@@ -145,10 +145,10 @@
       </div>
 
     </div>
-    <script src="../third_party/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-    <script src="../third_party/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="../third_party/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <script src="../third_party/iro.min.js" integrity="sha384-4wKYljBiUCSo5tJCQfnFKWf8TAHJxejy8pV2PItmsr0CBWu45fsMtEndOsWNynmn" crossorigin="anonymous"></script>
+    <script src="../third_party/jquery-3.3.1.min.js"></script>
+    <script src="../third_party/popper.min.js"></script>
+    <script src="../third_party/bootstrap.min.js"></script>
+    <script src="../third_party/iro.min.js"></script>
     <script src="../../dist/webml-polyfill.js"></script>
     <script src="../util/base.js"></script>
     <script src="../util/tflite/flatbuffers/js/flatbuffers.js"></script>

--- a/examples/object_detection/camera.html
+++ b/examples/object_detection/camera.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>WebML SSD MobileNet Camera Demo</title>
-    <link rel="stylesheet" href="../third_party/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="../third_party/bootstrap.min.css">
     <style>
       video {
         display: none;
@@ -80,9 +80,9 @@
       </div>
     </div>
     <canvas id="canvas" width=300 height=300></canvas>
-    <script src="../third_party/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-    <script src="../third_party/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="../third_party/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script src="../third_party/jquery-3.3.1.min.js"></script>
+    <script src="../third_party/popper.min.js"></script>
+    <script src="../third_party/bootstrap.min.js"></script>
     <script src="../third_party/stats.min.js"></script>
     <script src="../../dist/webml-polyfill.js"></script>
     <script src="../util/base.js"></script>

--- a/examples/object_detection/index.html
+++ b/examples/object_detection/index.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>WebML SSD MobileNet Demo</title>
-    <link rel="stylesheet" href="../third_party/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" href="../third_party/bootstrap.min.css">
     <style>
       img {
         display: none;
@@ -95,9 +95,9 @@
       </div>
     </div>
     <canvas id="canvas" width=300 height=300></canvas>
-    <script src="../third_party/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
-    <script src="../third_party/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="../third_party/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script src="../third_party/jquery-3.3.1.min.js"></script>
+    <script src="../third_party/popper.min.js"></script>
+    <script src="../third_party/bootstrap.min.js"></script>
     <script src="../../dist/webml-polyfill.js"></script>
     <script src="../util/base.js"></script>
     <script src="../util/tflite/flatbuffers/js/flatbuffers.js"></script>

--- a/examples/posenet/camera.html
+++ b/examples/posenet/camera.html
@@ -4,7 +4,7 @@
     <meta charset = "utf-8">
     <meta name = "viewport" content = "width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>WebML PoseNet Camera Demo</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
     <style>
       #my-gui-container {
         position: absolute;
@@ -88,9 +88,9 @@
       <div id="my-gui-container"></div>
       <div id="inferenceTime" class="col" align="center"></div>
     </div>
-    <script src = "https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src = "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script src = "https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <script src = "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"></script>
+    <script src = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
     <script src = "../third_party/stats.min.js"></script>
     <script src = "../../dist/webml-polyfill.js"></script>
     <script src = "../util/base.js"></script>

--- a/examples/posenet/index.html
+++ b/examples/posenet/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>WebML PoseNet Demo</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css">
     <style>
       #my-gui-container {
         position: relative;
@@ -125,9 +125,9 @@
     </div>
     <canvas hidden id = "scaleImage"></canvas>
 
-    <script src = "https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src = "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+    <script src = "https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
+    <script src = "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"></script>
+    <script src = "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
     <script type = "text/javascript" src = "../third_party/dat.gui.js"></script>
     <script src = "../../dist/webml-polyfill.js"></script>
     <script src = "../util/base.js"></script>

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>WebML Simple Model</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css" integrity="sha384-Zug+QiDoJOrZ5t4lssLdxGhVrurbmBWopoEl+M6BdEfwnCJZtKxi1KgxUyJq13dy" crossorigin="anonymous">    
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/css/bootstrap.min.css">    
   </head>
   <body>
     <nav class="navbar navbar-expand-md navbar-dark bg-dark" style="width:100%">
@@ -62,9 +62,9 @@
         </div>
       </div>
     </div>
-    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js"></script>
     <script src="../../dist/webml-polyfill.js"></script>
     <script src="SimpleModel.js"></script>
     <script src="main.js"></script>


### PR DESCRIPTION
Fix #510 
In windows, html page will fail to load resource if use Subresource Integrity. 
Now, delete SRI of all examples. 