### PR TITLE
[tool] Fix CI fail on Linux platform.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-loader": "^7.1.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
-    "chromedriver": "^2.43.1",
+    "chromedriver": "2.45.0",
     "fast-csv": "^2.4.1",
     "http-server": "^0.10.0",
     "ndarray": "^1.0.18",


### PR DESCRIPTION
@ibelem PTAL, thanks
This PR is to fix CI fail on Linux platform. 
Since Chrome of CI environment is 70, the latest chromedirver(2.46.628388) supports between 71 and 75, so modify chromedirver as 2.45.0 in package.json to support Chrome 70.