### PR TITLE
Update chrome version to 74.0.3729.131 for circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~
     docker:
-        - image: circleci/node:10.13.0-browsers
+        - image: circleci/node:latest-browsers
     steps:
       - checkout
       - run: npm install


### PR DESCRIPTION
fix #778 
circleCI image `circleci/node:lts-browsers`
circleCI image `circleci/node:latest-browsers`

Default chrome version was 74.0.3729.131

More information https://circleci.com/docs/2.0/docker-image-tags.json