### PR TITLE
[example] fix jitter issue for inference time

### DIFF
--- a/examples/static/css/style.css
+++ b/examples/static/css/style.css
@@ -1104,6 +1104,7 @@ footer {
 #inferenceresult th,
 #inferenceresult td {
   font-weight: 200;
+  min-width: 80px;
 }
 
 .prefer label {
@@ -2647,3 +2648,4 @@ button.xclose {
 .backendtooltip {
   text-align: left;
 }
+

--- a/examples/static/css/style.css
+++ b/examples/static/css/style.css
@@ -1185,6 +1185,9 @@ footer {
 .ir {
   color: rgba(25, 190, 225, 1.0);
   text-transform: lowercase;
+  min-width: 80px;
+  display: inline-block;
+  text-align: right;
 }
 
 .item {


### PR DESCRIPTION
Fix #774 
- Fix jitter issue in #/label/probability table of image classification with live camera view
- Fix jitter issue in inference time section

Test URL: https://ibelem.github.io/webml-website/examples/image_classification/?prefer=fast&b=WebML&m=mobilenet_v2_quant&t=tflite&s=camera&d=0

@huningxin @pinzhenx @Christywl PTAL