### PR TITLE
[Example] Supporting front-facing and rear cameras for mobile devices

### DIFF
--- a/examples/emotion_analysis/index.html
+++ b/examples/emotion_analysis/index.html
@@ -149,7 +149,7 @@
     <div class='container' id='container'>
       <a id='extra' href='#' class='mb-1 mt-3'>
         <h3 class='text-center ex' id='ictitle'>
-          Facial Landmark Detection
+          Emotion Analysis
         </h3>
         <span class='fa chevron-up'>
           <svg aria-hidden='true' data-prefix='fas' data-icon='chevron-up' class='svg-inline--fa fa-chevron-up fa-w-14'
@@ -266,6 +266,10 @@
                   </path>
                 </svg>
               </i>
+              <div id='cameraswitcher' class='custom-control custom-switch'>
+                <input type='checkbox' class='custom-control-input' id='cameraswitch'>
+                <label class='custom-control-label' for='cameraswitch'>Front-facing</label>
+              </div>
             </div>
           </div>
         </div>

--- a/examples/emotion_analysis/main.js
+++ b/examples/emotion_analysis/main.js
@@ -2,6 +2,7 @@ const canvasElement = document.getElementById('canvas');
 const canvasShowElement = document.getElementById('canvasshow');
 const canvasElement1 = document.getElementById('canvas1');
 
+let front = true;
 let currentEmotionModel = 'emotion_analysis_tflite';
 
 let faceDetector = new FaceDetecor(canvasElement);
@@ -64,7 +65,7 @@ const startPredict = async () => {
 const utilsPredictCamera = async () => {
   streaming = true;
   try {
-    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: 'environment' } });
+    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: (front ? 'user' : 'environment') } });
     video.srcObject = stream;
     track = stream.getTracks()[0];
     await showProgress('Camera inferencing ...');

--- a/examples/facial_landmark_detection/index.html
+++ b/examples/facial_landmark_detection/index.html
@@ -266,6 +266,10 @@
                   </path>
                 </svg>
               </i>
+              <div id='cameraswitcher' class='custom-control custom-switch'>
+                <input type='checkbox' class='custom-control-input' id='cameraswitch'>
+                <label class='custom-control-label' for='cameraswitch'>Front-facing</label>
+              </div>
             </div>
           </div>
         </div>

--- a/examples/facial_landmark_detection/main.js
+++ b/examples/facial_landmark_detection/main.js
@@ -2,6 +2,7 @@ const canvasElement = document.getElementById('canvas');
 const canvasShowElement = document.getElementById('canvasshow');
 const canvasElement1 = document.getElementById('canvas1');
 
+let front = true;
 let currentLandmarkModel = 'face_landmark_tflite';
 
 let faceDetector = new FaceDetecor(canvasElement);
@@ -64,7 +65,7 @@ const startPredict = async () => {
 const utilsPredictCamera = async () => {
   streaming = true;
   try {
-    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: 'environment' } });
+    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: (front ? 'user' : 'environment') } });
     video.srcObject = stream;
     track = stream.getTracks()[0];
     await showProgress('Camera inferencing ...');

--- a/examples/image_classification/index.html
+++ b/examples/image_classification/index.html
@@ -338,6 +338,10 @@
               </tbody>
             </table>
           </div>
+          <div id='cameraswitcher' class='custom-control custom-switch'>
+              <input type='checkbox' class='custom-control-input' id='cameraswitch'>
+              <label class='custom-control-label' for='cameraswitch'>Front-facing</label>
+          </div>
         </div>
       </div>
     </div>

--- a/examples/image_classification/main.js
+++ b/examples/image_classification/main.js
@@ -2,6 +2,7 @@ const canvasElement = document.getElementById('canvas');
 
 let utils = new Utils(canvasElement);
 utils.updateProgress = updateProgress;    //register updateProgress function if progressBar element exist
+let front = false;
 
 const updateResult = (result) => {
   try {
@@ -61,7 +62,7 @@ const utilsPredictCamera = async (backend, prefer) => {
   streaming = true;
   await showProgress('Camera inferencing ...');
   try {
-    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: 'environment' } });
+    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: (front ? 'user' : 'environment') } });
     video.srcObject = stream;
     track = stream.getTracks()[0];
     startPredictCamera();

--- a/examples/object_detection/index.html
+++ b/examples/object_detection/index.html
@@ -275,6 +275,10 @@
                 </svg>
               </i>
             </div>
+            <div id='cameraswitcher' class='custom-control custom-switch'>
+                <input type='checkbox' class='custom-control-input' id='cameraswitch'>
+                <label class='custom-control-label' for='cameraswitch'>Front-facing</label>
+            </div>
           </div>
         </div>
       </div>

--- a/examples/object_detection/main.js
+++ b/examples/object_detection/main.js
@@ -1,5 +1,6 @@
 const canvasElement = document.getElementById('canvas');
 const canvasShowElement = document.getElementById('canvasshow');
+let front = false;
 
 let utils = new Utils(canvasElement, canvasShowElement);
 utils.updateProgress = updateProgress;    //register updateProgress function if progressBar element exist
@@ -48,7 +49,7 @@ const utilsPredict = async (imageElement, backend, prefer) => {
 const utilsPredictCamera = async (backend, prefer) => {
   streaming = true;
   try {
-    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: 'environment' } });
+    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: (front ? 'user' : 'environment') } });
     video.srcObject = stream;
     track = stream.getTracks()[0];
     showProgress('Camera inferencing ...');

--- a/examples/semantic_segmentation/index.html
+++ b/examples/semantic_segmentation/index.html
@@ -248,6 +248,10 @@
             </i>
           </div>
           <canvas id='canvasvideo'></canvas>
+          <div id='cameraswitcher' class='custom-control custom-switch'>
+              <input type='checkbox' class='custom-control-input' id='cameraswitch'>
+              <label class='custom-control-label' for='cameraswitch'>Front-facing</label>
+          </div>
         </div>
         <div id='inference' class='shoulddisplay col-sm' style='display: none;'>
           <div class='row text-center tc' id='inferencetitle'>

--- a/examples/semantic_segmentation/main.js
+++ b/examples/semantic_segmentation/main.js
@@ -1,6 +1,7 @@
 const outputCanvas = document.getElementById('canvasvideo');
 
 let currentTab = 'image';
+let front = true;
 
 let clippedSize = [];
 let hoverPos = null;
@@ -61,7 +62,7 @@ const predictCamera = async () => {
     streaming = true;
     // let res = utils.getFittedResolution(4 / 3);
     // setCamResolution(res);
-    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: { facingMode: 'user' } });
+    let stream = await navigator.mediaDevices.getUserMedia({ audio: false, video: (front ? 'user' : 'environment') });
     videoElement.srcObject = stream;
     track = stream.getTracks()[0];
     showProgress('Inferencing ...');

--- a/examples/skeleton_detection/index.html
+++ b/examples/skeleton_detection/index.html
@@ -252,6 +252,10 @@
             </div>
             <video id='video' autoplay playsinline hidden></video>
             <canvas hidden id='scalevideo' width='640' height='480'></canvas>
+            <div id='cameraswitcher' class='custom-control custom-switch'>
+                <input type='checkbox' class='custom-control-input' id='cameraswitch'>
+                <label class='custom-control-label' for='cameraswitch'>Front-facing</label>
+            </div>
           </div>
         </div>
       </div>

--- a/examples/skeleton_detection/main.js
+++ b/examples/skeleton_detection/main.js
@@ -35,6 +35,7 @@ customContainer.appendChild(gui.domElement);
 guiState.scoreThreshold = 0.15;
 
 let currentTab = 'image';
+let front = true;
 
 const utils = new Utils();
 const canvassingle = document.getElementById('canvas');
@@ -181,7 +182,7 @@ const drawResult = async (predict = true, decode = true) => {
 
 const setupCamera = async () => {
   showProgress('Starting camera ...');
-  const stream = await navigator.mediaDevices.getUserMedia({ 'audio': false, 'video': {facingMode: 'user'}});
+  const stream = await navigator.mediaDevices.getUserMedia({ 'audio': false, 'video': {facingMode: (front ? 'user' : 'environment') }});
   video.srcObject = stream;
   track = stream.getTracks()[0];
   streaming = true;

--- a/examples/static/css/style.css
+++ b/examples/static/css/style.css
@@ -1156,12 +1156,16 @@ footer {
 }
 
 .webml-status-true {
-  margin-left: -6px;
+  margin-left: -5px;
   background: transparent;
   color: rgba(0, 0, 0, 0.8);
   border: 1px solid rgba(255, 111, 97, 0.9);
   display: inline-block;
   padding: 0.2rem 0.5rem;
+}
+
+.webml-status-true {
+  border-left: 0px;
 }
 
 .webml-status-true:hover {

--- a/examples/static/css/style.css
+++ b/examples/static/css/style.css
@@ -1283,7 +1283,7 @@ video.fullscreen, #canvasvideo.fullscreen, #canvasshow.fullscreen {
   width: auto;
   height: auto;
   object-fit: fill;
-  z-index: 2999;
+  z-index: 500;
   border: 0px;
 }
 
@@ -1320,7 +1320,7 @@ video.fullscreen, #canvasvideo.fullscreen, #canvasshow.fullscreen {
   right: 6rem;
   top: 2rem;
   font-size: 1.2rem;
-  z-index: 3002;
+  z-index: 502;
   border-radius: 0px;
   color: rgba(255, 255, 255, 0.7);
   background: rgba(25, 190, 225, 0.7);
@@ -1338,7 +1338,7 @@ video.fullscreen, #canvasvideo.fullscreen, #canvasshow.fullscreen {
   right: 2rem;
   top: 2rem;
   cursor: pointer;
-  z-index: 3003;
+  z-index: 503;
   color: rgba(255, 255, 255, 0.70);
 }
 
@@ -1349,7 +1349,7 @@ video.fullscreen, #canvasvideo.fullscreen, #canvasshow.fullscreen {
   font-size: 1.0rem;
   top: 5rem;
   text-transform: capitalize;
-  z-index: 3004;
+  z-index: 504;
   color: rgba(255, 255, 255, 0.70);
 }
 
@@ -1360,10 +1360,55 @@ video.fullscreen, #canvasvideo.fullscreen, #canvasshow.fullscreen {
   right: 2rem;
   font-size: 1.0rem;
   top: 7rem;
-  z-index: 3005;
+  z-index: 505;
   padding-top: 1rem;
   background-color: rgba(255, 255, 255, .03);
   color: rgba(255, 255, 255, 0.70);
+}
+
+.fullscreen .table {
+  color: rgba(255, 255, 255, 0.70);
+}
+
+
+#cameraswitcher {
+  top: 0px;
+  display: block;
+  margin-top: -50px;
+  font-weight: 200;
+  font-size: 13px;
+  text-align: center;
+}
+
+#cameraswitcher.fullscreen {
+  position: fixed;
+  display: block;
+  top: auto;
+  right: 2rem;
+  bottom: 2rem;
+  z-index: 506;
+  color: rgba(255, 255, 255, 0.70);
+}
+
+#imageclassification #cameraswitcher, #semanticsegmentation #cameraswitcher {
+  margin-top: 0px;
+}
+
+#posenet #cameraswitcher {
+  margin-top: 1rem;
+}
+
+#cameraswitcher.fullscreen .custom-control-input:checked~.custom-control-label::before {
+  border-color: rgba(255, 111, 97, 0.4);
+  background-color: rgba(255, 111, 97, 0.1);
+}
+
+#cameraswitcher.fullscreen .custom-control-input:checked~.custom-control-label::after {
+  background-color: rgba(255, 255, 255, 0.70);
+}
+
+#cameraswitcher.fullscreen .custom-control-label::before {
+  background-color: transparent;
 }
 
 #posenet #inference.fullscreen {
@@ -1374,13 +1419,15 @@ video.fullscreen, #canvasvideo.fullscreen, #canvasshow.fullscreen {
   width: 186px;
 }
 
+
+
 #my-gui-container.fullscreen {
   position: fixed;
   right: 2rem;
   font-size: 0.8rem;
   top: 8rem;
   text-transform: capitalize;
-  z-index: 3006;
+  z-index: 507;
   color: rgba(255, 255, 255, 0.70);
   padding: 10px;
 }
@@ -1430,7 +1477,7 @@ video.fullscreen, #canvasvideo.fullscreen, #canvasshow.fullscreen {
   color: rgba(255, 255, 255, 0.4);
   text-shadow: 0px 1px 1px rgba(0, 0, 0, 0.2);
   cursor: pointer;
-  z-index: 3000;
+  z-index: 600;
 }
 
 #fullscreen i svg:hover {

--- a/examples/static/css/style.css
+++ b/examples/static/css/style.css
@@ -113,7 +113,7 @@ body {
   position: fixed;
   left: 0;
   top: 0;
-  z-index: 1001;
+  z-index: 401;
 }
 
 .github-corner:hover .octo-arm {
@@ -528,7 +528,7 @@ a:hover {
   position: fixed;
   right: 0;
   top: 0;
-  z-index: 999;
+  z-index: 401;
   margin: 8px 10px 0 0;
   border: 0;
   background: none;

--- a/examples/static/js/ui.common.js
+++ b/examples/static/js/ui.common.js
@@ -288,6 +288,20 @@ let isBackendSwitch = () => {
   return $('#backendswitch').is(':checked')
 }
 
+let isFrontFacingSwitch = () => {
+  return $('#cameraswitch').is(':checked')
+}
+
+$(document).ready(() => {
+  $('#cameraswitch').prop('checked', front);
+
+  $('#cameraswitch').click(() => {
+    front = !front;
+    $('#cameraswitch').prop('checked', front);
+    updateBackend(us === 'camera', true);
+  })
+})
+
 $(document).ready(() => {
 
   if (us == 'camera') {
@@ -295,12 +309,14 @@ $(document).ready(() => {
     $('.nav-pills #cam').addClass('active');
     $('#imagetab').removeClass('active');
     $('#cameratab').addClass('active');
+    $('#cameraswitcher').show();
   } else {
     $('.nav-pills li').removeClass('active');
     $('.nav-pills #img').addClass('active');
     $('#cameratab').removeClass('active');
     $('#imagetab').addClass('active');
     $('#fps').html('');
+    $('#cameraswitcher').hide();
   }
 
   if (hasUrlParam('b')) {
@@ -536,6 +552,7 @@ $('#fullscreen i svg').click(() => {
   $('#fullscreen i').toggleClass('fullscreen');
   $('#ictitle').toggleClass('fullscreen');
   $('#inference').toggleClass('fullscreen');
+  $('#cameraswitcher').toggleClass('fullscreen');
 });
 
 $(document).ready(() => {
@@ -546,6 +563,7 @@ $(document).ready(() => {
     $('ul.nav-pills #img').addClass('active');
     $('#imagetab').addClass('active');
     $('#cameratab').removeClass('active');
+    $('#cameraswitcher').hide();
   });
 
   $('#cam').click(() => {
@@ -554,6 +572,7 @@ $(document).ready(() => {
     $('ul.nav-pills #cam').addClass('active');
     $('#cameratab').addClass('active');
     $('#imagetab').removeClass('active');
+    $('#cameraswitcher').fadeIn()
   });
 });
 

--- a/examples/static/js/ui.common.js
+++ b/examples/static/js/ui.common.js
@@ -299,7 +299,11 @@ $(document).ready(() => {
     $('#cameraswitch').click(() => {
       front = !front;
       $('#cameraswitch').prop('checked', front);
-      updateBackend(us === 'camera', true);
+      if (skeletonDetectionPath > -1) {
+        main(us === 'camera');
+      } else {
+        updateBackend(us === 'camera', true);
+      }
     })
 
     if (us == 'camera') {

--- a/examples/static/js/ui.common.js
+++ b/examples/static/js/ui.common.js
@@ -293,13 +293,35 @@ let isFrontFacingSwitch = () => {
 }
 
 $(document).ready(() => {
-  $('#cameraswitch').prop('checked', front);
-
-  $('#cameraswitch').click(() => {
-    front = !front;
+  if (/Mobi|Android|iPhone|iPad|iPod/.test(navigator.userAgent)) {
     $('#cameraswitch').prop('checked', front);
-    updateBackend(us === 'camera', true);
-  })
+
+    $('#cameraswitch').click(() => {
+      front = !front;
+      $('#cameraswitch').prop('checked', front);
+      updateBackend(us === 'camera', true);
+    })
+
+    if (us == 'camera') {
+      $('#cameraswitcher').show();
+    } else {
+      $('#cameraswitcher').hide();
+    }
+
+    $('#fullscreen i svg').click(() => {
+      $('#cameraswitcher').toggleClass('fullscreen');
+    })
+    
+    $('#img').click(() => {
+      $('#cameraswitcher').hide();
+    })
+
+    $('#cam').click(() => {
+      $('#cameraswitcher').fadeIn()
+    })
+  } else {
+    $('#cameraswitcher').hide();
+  }
 })
 
 $(document).ready(() => {
@@ -309,14 +331,12 @@ $(document).ready(() => {
     $('.nav-pills #cam').addClass('active');
     $('#imagetab').removeClass('active');
     $('#cameratab').addClass('active');
-    $('#cameraswitcher').show();
   } else {
     $('.nav-pills li').removeClass('active');
     $('.nav-pills #img').addClass('active');
     $('#cameratab').removeClass('active');
     $('#imagetab').addClass('active');
     $('#fps').html('');
-    $('#cameraswitcher').hide();
   }
 
   if (hasUrlParam('b')) {
@@ -552,7 +572,6 @@ $('#fullscreen i svg').click(() => {
   $('#fullscreen i').toggleClass('fullscreen');
   $('#ictitle').toggleClass('fullscreen');
   $('#inference').toggleClass('fullscreen');
-  $('#cameraswitcher').toggleClass('fullscreen');
 });
 
 $(document).ready(() => {
@@ -563,7 +582,6 @@ $(document).ready(() => {
     $('ul.nav-pills #img').addClass('active');
     $('#imagetab').addClass('active');
     $('#cameratab').removeClass('active');
-    $('#cameraswitcher').hide();
   });
 
   $('#cam').click(() => {
@@ -572,7 +590,6 @@ $(document).ready(() => {
     $('ul.nav-pills #cam').addClass('active');
     $('#cameratab').addClass('active');
     $('#imagetab').removeClass('active');
-    $('#cameraswitcher').fadeIn()
   });
 });
 

--- a/examples/super_resolution/main.js
+++ b/examples/super_resolution/main.js
@@ -1,6 +1,8 @@
 const inputCanvas = document.getElementById('inputCanvas');
 const outputCanvas = document.getElementById('outputCanvas');
 
+let front = false;
+
 let utils = new Utils();
 utils.updateProgress = updateProgress;
 


### PR DESCRIPTION
Fix #809  @Wenzhao-Xiang @pinzhenx PTAL

@Christywl please check if any issues for switching cameras on mobile or tablet which support front-facing and rear cameras

Check points:
1. Switch display and layout on normal vs fullscreen
2. Swicth should work on Android (mobile phones)
3. Switch should be hidden for desktop browsers
4. The init camera should be correct for use cases, e.g. the Landmark should be front-facing camera by default rather than environment (rear) camera. 