### PR TITLE
[CI] Ignore gh-pages branch for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,9 @@
 version: 2 
 jobs:
   build:
+    branches:
+      ignore:
+        - gh-pages
     working_directory: ~
     docker:
         - image: circleci/node:12.1.0-browsers


### PR DESCRIPTION
Always get CI failure when [updating gh-pages](https://github.com/intel/webml-polyfill/commits/gh-pages),  so ignore gh-pages branch in circle ci config file.

@BruceDai @shenx3x @miaobin PTAL