### PR TITLE
[Example] Add MPS badge when select sustained on Mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,4 @@ workflows:
   build-and-deploy:
     jobs:
       - build
-          filters:
-            branches:
-              ignore:
-                - gh-pages
+

--- a/examples/static/css/style.css
+++ b/examples/static/css/style.css
@@ -2864,3 +2864,14 @@ button.xclose {
     text-align: left;
   }
 }
+
+.nbackend {
+  margin-left: 6px !important;
+  margin-bottom: 2px !important;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 1.0) !important;
+  padding: 0px 6px 0px 6px !important;
+  box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.2);
+  text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
+  background: linear-gradient(to bottom right, rgba(255, 213, 188, 1.0), rgba(255, 110, 97, 1.0));
+}

--- a/examples/static/js/ui.common.js
+++ b/examples/static/js/ui.common.js
@@ -120,6 +120,15 @@ const trademarks = (allFormats) => {
   }
 }
 
+const updateNativeBackend = () => {
+  if(currentPrefer === 'sustained' & currentOS === 'Mac OS') {
+    let nativebackend = getNativeAPI(currentPrefer);
+    $('#l-sustained').append(`<span class='nbackend'>${nativebackend}</span>`);
+  } else {
+    $('#l-sustained').html('SUSTAINED_SPEED');
+  }
+}
+
 const constructModelTable = (modelList) => {
 
   const allFormats = new Set(modelList.map((m) => m.format));
@@ -198,9 +207,11 @@ const updateTitle = (name, backend, prefer, modelId) => {
   const model = getModelById(modelId);
   if(currentprefertext === 'None') {
     $('#ictitle').html(`${name} / ${backendtext} / ${model.modelName || 'None'}`);
+  } else if(currentPrefer === 'sustained' & currentOS === 'Mac OS') {
+    $('#ictitle').html(`${name} / ${backendtext} (${currentprefertext}/MPS) / ${model.modelName || 'None'}`);
   } else {
     $('#ictitle').html(`${name} / ${backendtext} (${currentprefertext}) / ${model.modelName || 'None'}`);
-  }
+  } 
 }
 
 $('#header').sticky({ topSpacing: 0, zIndex: '50' });
@@ -431,6 +442,9 @@ $(document).ready(() => {
   }
 
   updateBackendRadioUI(ub, up);
+
+  updateNativeBackend();
+
 });
 
 
@@ -539,12 +553,15 @@ if (skeletonDetectionPath <= -1) {
         currentPrefer = 'none';
       }
 
+      updateNativeBackend();
+
       strsearch = `?prefer=${currentPrefer}&b=${currentBackend}&m=${um}&s=${us}&d=${ud}`;
       window.history.pushState(null, null, strsearch);
       if (um === 'none') {
         showError('No model selected', 'Please select a model to start prediction.');
         return;
       }
+
       updateTitle(currentExample, currentBackend, currentPrefer, um);
       updateBackend(us === 'camera', true);
     });
@@ -579,12 +596,16 @@ if (skeletonDetectionPath <= -1) {
         currentBackend = 'WebML';
         currentPrefer = webnnId;
       }
+
+      updateNativeBackend();
+
       strsearch = `?prefer=${currentPrefer}&b=${currentBackend}&m=${um}&s=${us}&d=${ud}`;
       window.history.pushState(null, null, strsearch);
       if (um === 'none') {
         showError('No model selected', 'Please select a model to start prediction.');
         return;
       }
+
       updateTitle(currentExample, currentBackend, currentPrefer, um);
       updateBackend(us === 'camera', true);
     });


### PR DESCRIPTION
> do you still support api_info? flag? Latest build/examples don’t seem to support it. It’s a useful feature

When select "sustained" on Mac, it will show "MPS" text.

@Christywl PTAL
