### PR TITLE
[workload] Fix #964 model and label 404 issue from storage service

### DIFF
--- a/benchmark/resources/utils.js
+++ b/benchmark/resources/utils.js
@@ -138,10 +138,20 @@ async function loadUrl(url, binary) {
 }
 
 async function loadModelAndLabels(model, label=null) {
+  let arrayBuffer, bytes, text;
   let url = '../examples/util/';
-  let arrayBuffer = await this.loadUrl(url + model, true);
-  let bytes = new Uint8Array(arrayBuffer);
-  let text = label ? await this.loadUrl(url + label) : null;
+  if(model.toLowerCase().startsWith("https://") || model.toLowerCase().startsWith("http://")) {
+    arrayBuffer = await this.loadUrl(model, true);
+  } else {
+    arrayBuffer = await this.loadUrl(url + model, true);
+  }
+  bytes = new Uint8Array(arrayBuffer);
+  if(label.toLowerCase().startsWith("https://") || label.toLowerCase().startsWith("http://")) {
+    text = await this.loadUrl(label);
+  } else {
+    text = label ? await this.loadUrl(url + label) : null;
+  }
+
   return {
     bytes: bytes,
     text: text

--- a/benchmark/resources/utils.js
+++ b/benchmark/resources/utils.js
@@ -140,13 +140,13 @@ async function loadUrl(url, binary) {
 async function loadModelAndLabels(model, label=null) {
   let arrayBuffer, bytes, text;
   let url = '../examples/util/';
-  if(model.toLowerCase().startsWith("https://") || model.toLowerCase().startsWith("http://")) {
+  if (model.toLowerCase().startsWith("https://") || model.toLowerCase().startsWith("http://")) {
     arrayBuffer = await this.loadUrl(model, true);
   } else {
     arrayBuffer = await this.loadUrl(url + model, true);
   }
   bytes = new Uint8Array(arrayBuffer);
-  if(label.toLowerCase().startsWith("https://") || label.toLowerCase().startsWith("http://")) {
+  if (label.toLowerCase().startsWith("https://") || label.toLowerCase().startsWith("http://")) {
     text = await this.loadUrl(label);
   } else {
     text = label ? await this.loadUrl(url + label) : null;

--- a/benchmark/resources/utils_ic.js
+++ b/benchmark/resources/utils_ic.js
@@ -74,7 +74,7 @@ class ICBenchmark extends Benchmark {
         const networkFile = this.modelInfoDict.modelFile.replace(/bin$/, 'xml');
         let networkText;
 
-        if(networkFile.toLowerCase().startsWith("https://") || networkFile.toLowerCase().startsWith("http://")) {
+        if (networkFile.toLowerCase().startsWith("https://") || networkFile.toLowerCase().startsWith("http://")) {
           networkText = await loadUrl(networkFile, false);
         } else {
           networkText = await loadUrl('../examples/util/' + networkFile, false);

--- a/benchmark/resources/utils_ic.js
+++ b/benchmark/resources/utils_ic.js
@@ -72,7 +72,14 @@ class ICBenchmark extends Benchmark {
         break;
       case 'OpenVINO':
         const networkFile = this.modelInfoDict.modelFile.replace(/bin$/, 'xml');
-        const networkText = await loadUrl('../examples/util/' + networkFile, false);
+        let networkText;
+
+        if(networkFile.toLowerCase().startsWith("https://") || networkFile.toLowerCase().startsWith("http://")) {
+          networkText = await loadUrl(networkFile, false);
+        } else {
+          networkText = await loadUrl('../examples/util/' + networkFile, false);
+        }
+
         const weightsBuffer = loadResult.bytes.buffer;
         rawModel = new OpenVINOModel(networkText, weightsBuffer);
         importerClass = OpenVINOModelImporter;


### PR DESCRIPTION
Fix #964 

The original code in workload didn't consider the urls hosted from third party cloud service.

@BruceDai @cuiyanx PTAL