### PR TITLE
[example] IterateLayers tool can work for quant model under WASM for these examples: image_classification, super_resolution and semantic_segmentation

### DIFF
--- a/examples/image_classification/utils.js
+++ b/examples/image_classification/utils.js
@@ -271,7 +271,6 @@ class Utils {
     }
   }
 
-
   // for debugging
   async iterateLayers(configs, layerList) {
     if (!this.initialized) return;
@@ -286,6 +285,7 @@ class Utils {
         bin: OpenVINOModelImporter,
       }[fileExtension];
       const model = await new importer({
+        isQuantized: this.isQuantized,
         rawModel: this.rawModel,
         backend: config.backend,
         prefer: config.prefer || null,

--- a/examples/semantic_segmentation/utils.js
+++ b/examples/semantic_segmentation/utils.js
@@ -212,6 +212,7 @@ class Utils {
     let iterators = [];
     for (let config of configs) {
       let model = await new TFliteModelImporter({
+        isQuantized: this.isQuantized,
         rawModel: this.tfModel,
         backend: config.backend,
         prefer: config.prefer || null,

--- a/examples/super_resolution/utils.js
+++ b/examples/super_resolution/utils.js
@@ -228,6 +228,7 @@ class Utils {
     for (let config of configs) {
       let importer = this.modelFile.split('.').pop() === 'tflite' ? TFliteModelImporter : OnnxModelImporter;
       let model = await new importer({
+        isQuantized: this.isQuantized,
         rawModel: this.rawModel,
         backend: config.backend,
         prefer: config.prefer || null,

--- a/examples/util/onnx/OnnxModelImporter.js
+++ b/examples/util/onnx/OnnxModelImporter.js
@@ -1,5 +1,6 @@
 class OnnxModelImporter {
   constructor(kwargs) {
+    this._isQuantized = kwargs.isQuantized;
     this._rawModel = kwargs.rawModel;
     this._model = null;
     this._compilation;
@@ -100,7 +101,12 @@ class OnnxModelImporter {
       this._execution = await this._compilation.createExecution();
 
       const outputSize = this._getTensorTypeByName(outputName).dimensions.reduce((a, b) => a * b);
-      const outputTensor = new Float32Array(outputSize);
+      let outputTensor;
+      if (this._isQuantized) {
+        outputTensor = new Uint8Array(outputSize);
+      } else {
+        outputTensor = new Float32Array(outputSize);
+      }
       await this.compute(inputTensors, [outputTensor]);
       return {layerId: lastNode, outputName: outputName, tensor: outputTensor, outputIds: outputs, inputIds: inputs};
     }

--- a/examples/util/openvino/OpenVINOModelImporter.js
+++ b/examples/util/openvino/OpenVINOModelImporter.js
@@ -1,5 +1,6 @@
 class OpenVINOModelImporter {
   constructor(kwargs) {
+    this._isQuantized = kwargs.isQuantized;
     this._rawModel = kwargs.rawModel;
     this._model = null;
     this._compilation = null;
@@ -92,7 +93,12 @@ class OpenVINOModelImporter {
       this._execution = await this._compilation.createExecution();
 
       const outputSize = output.shape().reduce((a, b) => a * b);
-      const outputTensor = new Float32Array(outputSize);
+      let outputTensor;
+      if (this._isQuantized) {
+        outputTensor = new Uint8Array(outputSize);
+      } else {
+        outputTensor = new Float32Array(outputSize);
+      }
       await this.compute(inputTensors, [outputTensor]);
       return {
         layerId: lastNodeIdx, outputName: lastNode.name, tensor: outputTensor,

--- a/examples/util/tflite/TFliteModelImporter.js
+++ b/examples/util/tflite/TFliteModelImporter.js
@@ -1,5 +1,6 @@
 class TFliteModelImporter {
   constructor(kwargs) {
+    this._isQuantized = kwargs.isQuantized;
     this._rawModel = kwargs.rawModel;
     this._model = null;
     this._compilation;
@@ -194,7 +195,12 @@ class TFliteModelImporter {
       this._execution = await this._compilation.createExecution();
 
       const outputSize = graph.tensors(outputs[0]).shapeArray().reduce((a,b)=>a*b);
-      const outputTensor = new Float32Array(outputSize);  
+      let outputTensor;
+      if (this._isQuantized) {
+        outputTensor = new Uint8Array(outputSize);
+      } else {
+        outputTensor = new Float32Array(outputSize);
+      }
       await this.compute(inputTensors, [outputTensor]);
       return {layerId: lastNode, outputName: outputName, tensor: outputTensor};
     }


### PR DESCRIPTION
@ibelem  @BruceDai Please review, thanks! This tool can support models under WASM backend on Linux and Android, but can't work under WebML backend on Andriod.