### PR TITLE
[ci] Upgraded CircleCI using 13.1.0-browsers docker image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~
     docker:
-        - image: circleci/node:12.9.1-browsers
+        - image: circleci/node:13.1.0-browsers
     steps:
       - checkout
       - run: npm install


### PR DESCRIPTION
@ibelem The last PR #1069 couldn't be verified locally,  when it's merged, I found #1068 still reproduced online, so I submitted this one to both upgrade docker image for CircleCI.  PTAL, thanks. 