### PR TITLE
[example] Create a new execution for each prediction to fix #1060 Android bug

### DIFF
--- a/examples/util/onnx/OnnxModelImporter.js
+++ b/examples/util/onnx/OnnxModelImporter.js
@@ -44,12 +44,12 @@ class OnnxModelImporter {
     let start = performance.now();
     this._compilation.setPreference(getPreferCode(this._backend, this._prefer));
     await this._compilation.finish();
-    this._execution = await this._compilation.createExecution();
     let elapsed = performance.now() - start;
     console.log(`compilation time: ${elapsed.toFixed(2)} ms`);
   }
 
   async compute(inputTensors, outputTensors) {
+    this._execution = await this._compilation.createExecution();
     inputTensors.forEach((inputTensor, i) => {
       this._execution.setInput(i, inputTensor);
     });

--- a/examples/util/openvino/OpenVINOModelImporter.js
+++ b/examples/util/openvino/OpenVINOModelImporter.js
@@ -44,12 +44,12 @@ class OpenVINOModelImporter {
     let start = performance.now();
     this._compilation.setPreference(getPreferCode(this._backend, this._prefer));
     await this._compilation.finish();
-    this._execution = await this._compilation.createExecution();
     let elapsed = performance.now() - start;
     console.log(`compilation time: ${elapsed.toFixed(2)} ms`);
   }
 
   async compute(inputTensors, outputTensors) {
+    this._execution = await this._compilation.createExecution();
     inputTensors.forEach((inputTensor, i) => {
       this._execution.setInput(i, inputTensor);
     });

--- a/examples/util/tflite/TFliteModelImporter.js
+++ b/examples/util/tflite/TFliteModelImporter.js
@@ -45,12 +45,12 @@ class TFliteModelImporter {
     let start = performance.now();
     this._compilation.setPreference(getPreferCode(this._backend, this._prefer));
     await this._compilation.finish();
-    this._execution = await this._compilation.createExecution();
     let elapsed = performance.now() - start;
     console.log(`compilation time: ${elapsed.toFixed(2)} ms`);
   }
 
   async compute(inputTensors, outputTensors) {
+    this._execution = await this._compilation.createExecution();
     inputTensors.forEach((inputTensor, i) => {
       this._execution.setInput(i, inputTensor);
     });


### PR DESCRIPTION
I have verified these examples, now they can run successfully on Android 10 (Pixel 2 XL). Please help to review. Thanks! @BruceDai 