### PR TITLE
[test] Add CTS test cases for 'TENSOR_QUANT8_ASYMM_SIGNED'

### DIFF
--- a/test/cts/test/V1_0/add_quant8.js
+++ b/test/cts/test/V1_0/add_quant8.js
@@ -49,7 +49,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type1_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/avg_pool_quant8_1.js
+++ b/test/cts/test/V1_0/avg_pool_quant8_1.js
@@ -48,7 +48,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type0_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/avg_pool_quant8_2.js
+++ b/test/cts/test/V1_0/avg_pool_quant8_2.js
@@ -53,7 +53,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/avg_pool_quant8_3.js
+++ b/test/cts/test/V1_0/avg_pool_quant8_3.js
@@ -53,7 +53,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/avg_pool_quant8_4.js
+++ b/test/cts/test/V1_0/avg_pool_quant8_4.js
@@ -48,7 +48,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type0_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/avg_pool_quant8_5.js
+++ b/test/cts/test/V1_0/avg_pool_quant8_5.js
@@ -50,7 +50,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/concat_quant8_1.js
+++ b/test/cts/test/V1_0/concat_quant8_1.js
@@ -49,7 +49,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(result_output[i], result_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(result_output[i], result_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/concat_quant8_2.js
+++ b/test/cts/test/V1_0/concat_quant8_2.js
@@ -51,7 +51,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/concat_quant8_3.js
+++ b/test/cts/test/V1_0/concat_quant8_3.js
@@ -51,7 +51,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8.js
+++ b/test/cts/test/V1_0/conv_quant8.js
@@ -60,7 +60,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_2.js
+++ b/test/cts/test/V1_0/conv_quant8_2.js
@@ -63,7 +63,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_channels.js
+++ b/test/cts/test/V1_0/conv_quant8_channels.js
@@ -60,7 +60,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_channels_weights_as_inputs.js
+++ b/test/cts/test/V1_0/conv_quant8_channels_weights_as_inputs.js
@@ -63,7 +63,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_large.js
+++ b/test/cts/test/V1_0/conv_quant8_large.js
@@ -60,7 +60,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_large_weights_as_inputs.js
+++ b/test/cts/test/V1_0/conv_quant8_large_weights_as_inputs.js
@@ -63,7 +63,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_overflow.js
+++ b/test/cts/test/V1_0/conv_quant8_overflow.js
@@ -60,7 +60,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_overflow_weights_as_inputs.js
+++ b/test/cts/test/V1_0/conv_quant8_overflow_weights_as_inputs.js
@@ -63,7 +63,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/conv_quant8_weights_as_inputs.js
+++ b/test/cts/test/V1_0/conv_quant8_weights_as_inputs.js
@@ -63,7 +63,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/depthwise_conv2d_quant8.js
+++ b/test/cts/test/V1_0/depthwise_conv2d_quant8.js
@@ -61,7 +61,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/depthwise_conv2d_quant8_2.js
+++ b/test/cts/test/V1_0/depthwise_conv2d_quant8_2.js
@@ -63,7 +63,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type4_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/depthwise_conv2d_quant8_large.js
+++ b/test/cts/test/V1_0/depthwise_conv2d_quant8_large.js
@@ -61,7 +61,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/depthwise_conv2d_quant8_large_weights_as_inputs.js
+++ b/test/cts/test/V1_0/depthwise_conv2d_quant8_large_weights_as_inputs.js
@@ -64,7 +64,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/depthwise_conv2d_quant8_weights_as_inputs.js
+++ b/test/cts/test/V1_0/depthwise_conv2d_quant8_weights_as_inputs.js
@@ -64,7 +64,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/fully_connected_quant8.js
+++ b/test/cts/test/V1_0/fully_connected_quant8.js
@@ -54,7 +54,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/fully_connected_quant8_2.js
+++ b/test/cts/test/V1_0/fully_connected_quant8_2.js
@@ -54,7 +54,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/fully_connected_quant8_large.js
+++ b/test/cts/test/V1_0/fully_connected_quant8_large.js
@@ -52,7 +52,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/fully_connected_quant8_large_weights_as_inputs.js
+++ b/test/cts/test/V1_0/fully_connected_quant8_large_weights_as_inputs.js
@@ -55,7 +55,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/fully_connected_quant8_weights_as_inputs.js
+++ b/test/cts/test/V1_0/fully_connected_quant8_weights_as_inputs.js
@@ -57,7 +57,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/logistic_quant8_1.js
+++ b/test/cts/test/V1_0/logistic_quant8_1.js
@@ -40,7 +40,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type1_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/logistic_quant8_2.js
+++ b/test/cts/test/V1_0/logistic_quant8_2.js
@@ -40,7 +40,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type1_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/max_pool_quant8_1.js
+++ b/test/cts/test/V1_0/max_pool_quant8_1.js
@@ -48,7 +48,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type0_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/max_pool_quant8_2.js
+++ b/test/cts/test/V1_0/max_pool_quant8_2.js
@@ -53,7 +53,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/max_pool_quant8_3.js
+++ b/test/cts/test/V1_0/max_pool_quant8_3.js
@@ -53,7 +53,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/max_pool_quant8_4.js
+++ b/test/cts/test/V1_0/max_pool_quant8_4.js
@@ -50,7 +50,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/mul_quant8.js
+++ b/test/cts/test/V1_0/mul_quant8.js
@@ -49,7 +49,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(op3_output[i], op3_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op3_output[i], op3_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/softmax_quant8_1.js
+++ b/test/cts/test/V1_0/softmax_quant8_1.js
@@ -44,7 +44,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_0/softmax_quant8_2.js
+++ b/test/cts/test/V1_0/softmax_quant8_2.js
@@ -44,7 +44,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_1/batch_to_space_quant8_1.js
+++ b/test/cts/test/V1_1/batch_to_space_quant8_1.js
@@ -45,7 +45,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_1/transpose_quant8_1.js
+++ b/test/cts/test/V1_1/transpose_quant8_1.js
@@ -45,7 +45,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type2_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_2/avg_pool_v1_2.js
+++ b/test/cts/test/V1_2/avg_pool_v1_2.js
@@ -267,7 +267,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type20_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -507,7 +507,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type47_length; ++i) {
-      assert.isTrue(almostEqualCTS(op44_output[i], op44_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op44_output[i], op44_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_2/conv2d_per_channel.js
+++ b/test/cts/test/V1_2/conv2d_per_channel.js
@@ -73,7 +73,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -150,7 +150,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -224,7 +224,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -301,7 +301,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_2/conv2d_v1_2.js
+++ b/test/cts/test/V1_2/conv2d_v1_2.js
@@ -212,7 +212,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type33_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -286,7 +286,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type33_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -579,7 +579,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type33_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -656,7 +656,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type33_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -918,7 +918,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type49_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -983,7 +983,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type49_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -1242,7 +1242,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type49_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -1310,7 +1310,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type49_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -1588,7 +1588,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type57_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -1660,7 +1660,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type57_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -1953,7 +1953,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type57_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -2028,7 +2028,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type57_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -2317,7 +2317,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type70_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -2391,7 +2391,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type70_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -2463,7 +2463,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type73_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -2758,7 +2758,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type70_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -2835,7 +2835,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type70_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -2910,7 +2910,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type73_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 

--- a/test/cts/test/V1_2/depthwise_conv2d_per_channel.js
+++ b/test/cts/test/V1_2/depthwise_conv2d_per_channel.js
@@ -76,7 +76,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -156,7 +156,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type3_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -233,7 +233,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type8_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -313,7 +313,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type8_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -390,7 +390,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type8_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -470,7 +470,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type8_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_2/depthwise_conv2d_v1_2.js
+++ b/test/cts/test/V1_2/depthwise_conv2d_v1_2.js
@@ -298,7 +298,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type21_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -375,7 +375,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type24_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -451,7 +451,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type21_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -762,7 +762,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type21_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -842,7 +842,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type24_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -921,7 +921,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type21_length; ++i) {
-      assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op4_output[i], op4_expect[i]));
     }
   });
 
@@ -1189,7 +1189,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type39_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -1257,7 +1257,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type39_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -1537,7 +1537,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type39_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -1608,7 +1608,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type39_length; ++i) {
-      assert.isTrue(almostEqualCTS(op41_output[i], op41_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op41_output[i], op41_expect[i]));
     }
   });
 
@@ -1906,7 +1906,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type54_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -1983,7 +1983,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type54_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -2293,7 +2293,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type54_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -2373,7 +2373,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type54_length; ++i) {
-      assert.isTrue(almostEqualCTS(op42_output[i], op42_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op42_output[i], op42_expect[i]));
     }
   });
 
@@ -2671,7 +2671,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type64_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -2748,7 +2748,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type64_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -3058,7 +3058,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type64_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 
@@ -3138,7 +3138,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type64_length; ++i) {
-      assert.isTrue(almostEqualCTS(op43_output[i], op43_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op43_output[i], op43_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_2/softmax_v1_2.js
+++ b/test/cts/test/V1_2/softmax_v1_2.js
@@ -173,7 +173,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type20_length; ++i) {
-      assert.isTrue(almostEqualCTS(op2_output[i], op2_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op2_output[i], op2_expect[i]));
     }
   });
 
@@ -347,7 +347,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type20_length; ++i) {
-      assert.isTrue(almostEqualCTS(op2_output[i], op2_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op2_output[i], op2_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_2/transpose_v1_2.js
+++ b/test/cts/test/V1_2/transpose_v1_2.js
@@ -137,7 +137,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type14_length; ++i) {
-      assert.isTrue(almostEqualCTS(output_output[i], output_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(output_output[i], output_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_3/conv2d_quant8_signed.js
+++ b/test/cts/test/V1_3/conv2d_quant8_signed.js
@@ -1,0 +1,510 @@
+// Generated file (from: conv2d_quant8_signed.mod.py). Do not edit
+describe('CTS', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+
+  it('check result for Conv2d quant8 signed example-1', async function() {
+    // For 'Conv2d quant8 signed' example: examples
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op15_value = [10, 10, 10, 10, 10, 10];
+    let op45_expect = [9, 13, 17, 9, 13, 17, 9, 13, 17];
+
+    let type10 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 1, 3], scale: 1.0, zeroPoint: 0};
+    let type10_length = product(type10.dimensions);
+    let type4 = {type: nn.INT32};
+    let type7 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 1, 2], scale: 0.5, zeroPoint: 0};
+    let type7_length = product(type7.dimensions);
+    let type8 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 2]};
+    let type8_length = product(type8.dimensions);
+    let type9 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type9_length = product(type9.dimensions);
+
+    let op15 = operandIndex++;
+    model.addOperand(type7);
+    let op25 = operandIndex++;
+    model.addOperand(type8);
+    model.setOperandSymmPerChannelQuantParams(op25, {channelDim: 0, scales: new Float32Array([0.5, 0.75, 1.0])});
+    let op35 = operandIndex++;
+    model.addOperand(type9);
+    let param36 = operandIndex++;
+    model.addOperand(type4);
+    let param37 = operandIndex++;
+    model.addOperand(type4);
+    let param38 = operandIndex++;
+    model.addOperand(type4);
+    let param39 = operandIndex++;
+    model.addOperand(type4);
+    let param40 = operandIndex++;
+    model.addOperand(type4);
+    let param41 = operandIndex++;
+    model.addOperand(type4);
+    let param42 = operandIndex++;
+    model.addOperand(type4);
+    let op45 = operandIndex++;
+    model.addOperand(type10);
+
+    model.setOperandValue(op25, new Int8Array([1, 2, 1, 2, 1, 2]));
+    model.setOperandValue(op35, new Int32Array([4, 4, 4]));
+    model.setOperandValue(param36, new Int32Array([0]));
+    model.setOperandValue(param37, new Int32Array([0]));
+    model.setOperandValue(param38, new Int32Array([0]));
+    model.setOperandValue(param39, new Int32Array([0]));
+    model.setOperandValue(param40, new Int32Array([1]));
+    model.setOperandValue(param41, new Int32Array([1]));
+    model.setOperandValue(param42, new Int32Array([0]));
+    model.addOperation(nn.CONV_2D, [op15, op25, op35, param36, param37, param38, param39, param40, param41, param42], [op45]);
+
+    model.identifyInputsAndOutputs([op15], [op45]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op15_input = new Int8Array(op15_value);
+    execution.setInput(0, op15_input);
+    let op45_output = new Int8Array(type10_length);
+    execution.setOutput(0, op45_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type10_length; ++i) {
+      assert.isTrue(almostEqualCTS(op45_output[i], op45_expect[i]));
+    }
+  });
+
+  it('check result for Conv2d quant8 signed example-2', async function() {
+    // For 'Conv2d quant8 signed' example: examples_layouts_nhwc
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op16_value = [10, -20, 10, -20, 10, -20];
+    let op46_expect = [-7, -10, -13, -7, -10, -13, -7, -10, -13];
+
+    let type10 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 1, 3], scale: 1.0, zeroPoint: 0};
+    let type10_length = product(type10.dimensions);
+    let type11 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 2]};
+    let type11_length = product(type11.dimensions);
+    let type4 = {type: nn.INT32};
+    let type7 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 1, 2], scale: 0.5, zeroPoint: 0};
+    let type7_length = product(type7.dimensions);
+    let type9 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type9_length = product(type9.dimensions);
+
+    let op16 = operandIndex++;
+    model.addOperand(type7);
+    let op26 = operandIndex++;
+    model.addOperand(type11);
+    model.setOperandSymmPerChannelQuantParams(op26, {channelDim: 0, scales: new Float32Array([0.5, 0.75, 1.0])});
+    let op36 = operandIndex++;
+    model.addOperand(type9);
+    let param43 = operandIndex++;
+    model.addOperand(type4);
+    let param44 = operandIndex++;
+    model.addOperand(type4);
+    let param45 = operandIndex++;
+    model.addOperand(type4);
+    let param46 = operandIndex++;
+    model.addOperand(type4);
+    let param47 = operandIndex++;
+    model.addOperand(type4);
+    let param48 = operandIndex++;
+    model.addOperand(type4);
+    let param49 = operandIndex++;
+    model.addOperand(type4);
+    let op46 = operandIndex++;
+    model.addOperand(type10);
+
+    model.setOperandValue(op26, new Int8Array([1, 2, 1, 2, 1, 2]));
+    model.setOperandValue(op36, new Int32Array([4, 4, 4]));
+    model.setOperandValue(param43, new Int32Array([0]));
+    model.setOperandValue(param44, new Int32Array([0]));
+    model.setOperandValue(param45, new Int32Array([0]));
+    model.setOperandValue(param46, new Int32Array([0]));
+    model.setOperandValue(param47, new Int32Array([1]));
+    model.setOperandValue(param48, new Int32Array([1]));
+    model.setOperandValue(param49, new Int32Array([0]));
+    model.addOperation(nn.CONV_2D, [op16, op26, op36, param43, param44, param45, param46, param47, param48, param49], [op46]);
+
+    model.identifyInputsAndOutputs([op16], [op46]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op16_input = new Int8Array(op16_value);
+    execution.setInput(0, op16_input);
+    let op46_output = new Int8Array(type10_length);
+    execution.setOutput(0, op46_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type10_length; ++i) {
+      assert.isTrue(almostEqualCTS(op46_output[i], op46_expect[i]));
+    }
+  });
+
+  it('check result for Conv2d quant8 signed example-3', async function() {
+    // For 'Conv2d quant8 signed' example: examples_nhwc_channelQuant8
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op17_value = [-126, -126, -126, -126, -127, -126, -126, -126, -126];
+    let op47_expect = [-121, -121, -121, -121];
+
+    let type4 = {type: nn.INT32};
+    let type51 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 3, 1], scale: 0.5, zeroPoint: -128};
+    let type51_length = product(type51.dimensions);
+    let type54 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 2, 1], scale: 0.125, zeroPoint: -128};
+    let type54_length = product(type54.dimensions);
+    let type72 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [1, 2, 2, 1]};
+    let type72_length = product(type72.dimensions);
+    let type73 = {type: nn.TENSOR_INT32, dimensions: [1]};
+    let type73_length = product(type73.dimensions);
+
+    let op17 = operandIndex++;
+    model.addOperand(type51);
+    let op27 = operandIndex++;
+    model.addOperand(type72);
+    model.setOperandSymmPerChannelQuantParams(op27, {channelDim: 0, scales: new Float32Array([0.125])});
+    let op37 = operandIndex++;
+    model.addOperand(type73);
+    let param70 = operandIndex++;
+    model.addOperand(type4);
+    let param71 = operandIndex++;
+    model.addOperand(type4);
+    let param72 = operandIndex++;
+    model.addOperand(type4);
+    let param73 = operandIndex++;
+    model.addOperand(type4);
+    let param74 = operandIndex++;
+    model.addOperand(type4);
+    let param75 = operandIndex++;
+    model.addOperand(type4);
+    let param76 = operandIndex++;
+    model.addOperand(type4);
+    let op47 = operandIndex++;
+    model.addOperand(type54);
+
+    model.setOperandValue(op27, new Int8Array([2, 2, 2, 2]));
+    model.setOperandValue(op37, new Int32Array([0]));
+    model.setOperandValue(param70, new Int32Array([0]));
+    model.setOperandValue(param71, new Int32Array([0]));
+    model.setOperandValue(param72, new Int32Array([0]));
+    model.setOperandValue(param73, new Int32Array([0]));
+    model.setOperandValue(param74, new Int32Array([1]));
+    model.setOperandValue(param75, new Int32Array([1]));
+    model.setOperandValue(param76, new Int32Array([0]));
+    model.addOperation(nn.CONV_2D, [op17, op27, op37, param70, param71, param72, param73, param74, param75, param76], [op47]);
+
+    model.identifyInputsAndOutputs([op17], [op47]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op17_input = new Int8Array(op17_value);
+    execution.setInput(0, op17_input);
+    let op47_output = new Int8Array(type54_length);
+    execution.setOutput(0, op47_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type54_length; ++i) {
+      assert.isTrue(almostEqualCTS(op47_output[i], op47_expect[i]));
+    }
+  });
+
+  it('check result for Conv2d quant8 signed example-4', async function() {
+    // For 'Conv2d quant8 signed' example: examples_nhwc_channelQuant8_2
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op18_value = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23];
+    let op48_expect = [-78, -78, -78, -78, -43, 34, 79, -78, -78, -44, -17, -78];
+
+    let type4 = {type: nn.INT32};
+    let type74 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 4, 1], scale: 0.5, zeroPoint: -1};
+    let type74_length = product(type74.dimensions);
+    let type76 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 4, 1], scale: 1.0, zeroPoint: -78};
+    let type76_length = product(type76.dimensions);
+    let type77 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [1, 3, 3, 1]};
+    let type77_length = product(type77.dimensions);
+    let type78 = {type: nn.TENSOR_INT32, dimensions: [1]};
+    let type78_length = product(type78.dimensions);
+
+    let op18 = operandIndex++;
+    model.addOperand(type74);
+    let op28 = operandIndex++;
+    model.addOperand(type77);
+    model.setOperandSymmPerChannelQuantParams(op28, {channelDim: 0, scales: new Float32Array([0.5])});
+    let op38 = operandIndex++;
+    model.addOperand(type78);
+    let param77 = operandIndex++;
+    model.addOperand(type4);
+    let param78 = operandIndex++;
+    model.addOperand(type4);
+    let param79 = operandIndex++;
+    model.addOperand(type4);
+    let param80 = operandIndex++;
+    model.addOperand(type4);
+    let op48 = operandIndex++;
+    model.addOperand(type76);
+
+    model.setOperandValue(op28, new Int8Array([2, 8, 14, 4, 10, 16, 6, 12, 18]));
+    model.setOperandValue(op38, new Int32Array([-800]));
+    model.setOperandValue(param77, new Int32Array([1]));
+    model.setOperandValue(param78, new Int32Array([1]));
+    model.setOperandValue(param79, new Int32Array([1]));
+    model.setOperandValue(param80, new Int32Array([1]));
+    model.addOperation(nn.CONV_2D, [op18, op28, op38, param77, param78, param79, param80], [op48]);
+
+    model.identifyInputsAndOutputs([op18], [op48]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op18_input = new Int8Array(op18_value);
+    execution.setInput(0, op18_input);
+    let op48_output = new Int8Array(type76_length);
+    execution.setOutput(0, op48_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type76_length; ++i) {
+      assert.isTrue(almostEqualCTS(op48_output[i], op48_expect[i]));
+    }
+  });
+
+  it('check result for Conv2d quant8 signed example-5', async function() {
+    // For 'Conv2d quant8 signed' example: examples_channel_nhwc_channelQuant8
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op19_value = [-118, -118, -118];
+    let op49_expect = [-98, -53, -8];
+
+    let type4 = {type: nn.INT32};
+    let type45 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 1, 1, 3], scale: 0.5, zeroPoint: -128};
+    let type45_length = product(type45.dimensions);
+    let type82 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 3]};
+    let type82_length = product(type82.dimensions);
+    let type83 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type83_length = product(type83.dimensions);
+
+    let op19 = operandIndex++;
+    model.addOperand(type45);
+    let op29 = operandIndex++;
+    model.addOperand(type82);
+    model.setOperandSymmPerChannelQuantParams(op29, {channelDim: 0, scales: new Float32Array([0.5, 0.4, 0.3])});
+    let op39 = operandIndex++;
+    model.addOperand(type83);
+    let param81 = operandIndex++;
+    model.addOperand(type4);
+    let param82 = operandIndex++;
+    model.addOperand(type4);
+    let param83 = operandIndex++;
+    model.addOperand(type4);
+    let param84 = operandIndex++;
+    model.addOperand(type4);
+    let param85 = operandIndex++;
+    model.addOperand(type4);
+    let param86 = operandIndex++;
+    model.addOperand(type4);
+    let param87 = operandIndex++;
+    model.addOperand(type4);
+    let op49 = operandIndex++;
+    model.addOperand(type45);
+
+    model.setOperandValue(op29, new Int8Array([1, 2, 3, 5, 6, 8, 12, 13, 15]));
+    model.setOperandValue(op39, new Int32Array([0, 0, 0]));
+    model.setOperandValue(param81, new Int32Array([0]));
+    model.setOperandValue(param82, new Int32Array([0]));
+    model.setOperandValue(param83, new Int32Array([0]));
+    model.setOperandValue(param84, new Int32Array([0]));
+    model.setOperandValue(param85, new Int32Array([1]));
+    model.setOperandValue(param86, new Int32Array([1]));
+    model.setOperandValue(param87, new Int32Array([0]));
+    model.addOperation(nn.CONV_2D, [op19, op29, op39, param81, param82, param83, param84, param85, param86, param87], [op49]);
+
+    model.identifyInputsAndOutputs([op19], [op49]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op19_input = new Int8Array(op19_value);
+    execution.setInput(0, op19_input);
+    let op49_output = new Int8Array(type45_length);
+    execution.setOutput(0, op49_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type45_length; ++i) {
+      assert.isTrue(almostEqualCTS(op49_output[i], op49_expect[i]));
+    }
+  });
+
+  it('check result for Conv2d quant8 signed example-6', async function() {
+    // For 'Conv2d quant8 signed' example: examples_large_nhwc_channelQuant8
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op110_value = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36];
+    let op410_expect = [-113, -110, -107, -95, -88, -80, -77, -65, -53, -59, -42, -26, -41, -20, 1, -23, 2, 28];
+
+    let type4 = {type: nn.INT32};
+    let type86 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 3, 3], scale: 0.5, zeroPoint: 0};
+    let type86_length = product(type86.dimensions);
+    let type88 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 3, 3], scale: 2.0, zeroPoint: -128};
+    let type88_length = product(type88.dimensions);
+    let type89 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 3]};
+    let type89_length = product(type89.dimensions);
+    let type90 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type90_length = product(type90.dimensions);
+
+    let op110 = operandIndex++;
+    model.addOperand(type86);
+    let op210 = operandIndex++;
+    model.addOperand(type89);
+    model.setOperandSymmPerChannelQuantParams(op210, {channelDim: 0, scales: new Float32Array([0.5, 1.0, 0.5])});
+    let op310 = operandIndex++;
+    model.addOperand(type90);
+    let param88 = operandIndex++;
+    model.addOperand(type4);
+    let param89 = operandIndex++;
+    model.addOperand(type4);
+    let param90 = operandIndex++;
+    model.addOperand(type4);
+    let param91 = operandIndex++;
+    model.addOperand(type4);
+    let param92 = operandIndex++;
+    model.addOperand(type4);
+    let param93 = operandIndex++;
+    model.addOperand(type4);
+    let param94 = operandIndex++;
+    model.addOperand(type4);
+    let op410 = operandIndex++;
+    model.addOperand(type88);
+
+    model.setOperandValue(op210, new Int8Array([2, 8, 14, 2, 5, 8, 6, 12, 18]));
+    model.setOperandValue(op310, new Int32Array([0, 0, 0]));
+    model.setOperandValue(param88, new Int32Array([0]));
+    model.setOperandValue(param89, new Int32Array([0]));
+    model.setOperandValue(param90, new Int32Array([0]));
+    model.setOperandValue(param91, new Int32Array([0]));
+    model.setOperandValue(param92, new Int32Array([1]));
+    model.setOperandValue(param93, new Int32Array([1]));
+    model.setOperandValue(param94, new Int32Array([0]));
+    model.addOperation(nn.CONV_2D, [op110, op210, op310, param88, param89, param90, param91, param92, param93, param94], [op410]);
+
+    model.identifyInputsAndOutputs([op110], [op410]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op110_input = new Int8Array(op110_value);
+    execution.setInput(0, op110_input);
+    let op410_output = new Int8Array(type88_length);
+    execution.setOutput(0, op410_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type88_length; ++i) {
+      assert.isTrue(almostEqualCTS(op410_output[i], op410_expect[i]));
+    }
+  });
+
+  it('check result for Conv2d quant8 signed example-7', async function() {
+    // For 'Conv2d quant8 signed' example: examples_large_nhwc_channelQuant8_2
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op110_value = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
+    let op410_expect = [29, 35, 41, 65, 80, 95, 101, 125, 149, 137, 170, 203, 173, 215, 257, 209, 260, 311];
+
+    let type4 = {type: nn.INT32};
+    let type91 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 3, 3], scale: 1.0, zeroPoint: -1};
+    let type91_length = product(type91.dimensions);
+    let type92 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 3]};
+    let type92_length = product(type92.dimensions);
+    let type93 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type93_length = product(type93.dimensions);
+
+    let op110 = operandIndex++;
+    model.addOperand(type91);
+    let op210 = operandIndex++;
+    model.addOperand(type92);
+    model.setOperandSymmPerChannelQuantParams(op210, {channelDim: 0, scales: new Float32Array([0.5, 1.0, 1.005])});
+    let op310 = operandIndex++;
+    model.addOperand(type93);
+    let param88 = operandIndex++;
+    model.addOperand(type4);
+    let param89 = operandIndex++;
+    model.addOperand(type4);
+    let param90 = operandIndex++;
+    model.addOperand(type4);
+    let param91 = operandIndex++;
+    model.addOperand(type4);
+    let param92 = operandIndex++;
+    model.addOperand(type4);
+    let param93 = operandIndex++;
+    model.addOperand(type4);
+    let param94 = operandIndex++;
+    model.addOperand(type4);
+    let op410 = operandIndex++;
+    model.addOperand(type91);
+
+    model.setOperandValue(op210, new Int8Array([2, 8, 14, 2, 5, 8, 3, 6, 9]));
+    model.setOperandValue(op310, new Int32Array([0, 0, 0]));
+    model.setOperandValue(param88, new Int32Array([0]));
+    model.setOperandValue(param89, new Int32Array([0]));
+    model.setOperandValue(param90, new Int32Array([0]));
+    model.setOperandValue(param91, new Int32Array([0]));
+    model.setOperandValue(param92, new Int32Array([1]));
+    model.setOperandValue(param93, new Int32Array([1]));
+    model.setOperandValue(param94, new Int32Array([0]));
+    model.addOperation(nn.CONV_2D, [op110, op210, op310, param88, param89, param90, param91, param92, param93, param94], [op410]);
+
+    model.identifyInputsAndOutputs([op110], [op410]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op110_input = new Int8Array(op110_value);
+    execution.setInput(0, op110_input);
+    let op410_output = new Int8Array(type91_length);
+    execution.setOutput(0, op410_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type91_length; ++i) {
+      assert.isTrue(almostEqualCTS(op410_output[i], op410_expect[i]));
+    }
+  });
+});

--- a/test/cts/test/V1_3/conv2d_quant8_signed.js
+++ b/test/cts/test/V1_3/conv2d_quant8_signed.js
@@ -73,7 +73,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type10_length; ++i) {
-      assert.isTrue(almostEqualCTS(op45_output[i], op45_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op45_output[i], op45_expect[i]));
     }
   });
 
@@ -147,7 +147,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type10_length; ++i) {
-      assert.isTrue(almostEqualCTS(op46_output[i], op46_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op46_output[i], op46_expect[i]));
     }
   });
 
@@ -221,7 +221,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type54_length; ++i) {
-      assert.isTrue(almostEqualCTS(op47_output[i], op47_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op47_output[i], op47_expect[i]));
     }
   });
 
@@ -286,7 +286,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type76_length; ++i) {
-      assert.isTrue(almostEqualCTS(op48_output[i], op48_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op48_output[i], op48_expect[i]));
     }
   });
 
@@ -358,7 +358,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type45_length; ++i) {
-      assert.isTrue(almostEqualCTS(op49_output[i], op49_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op49_output[i], op49_expect[i]));
     }
   });
 
@@ -432,7 +432,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type88_length; ++i) {
-      assert.isTrue(almostEqualCTS(op410_output[i], op410_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op410_output[i], op410_expect[i]));
     }
   });
 
@@ -504,7 +504,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type91_length; ++i) {
-      assert.isTrue(almostEqualCTS(op410_output[i], op410_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op410_output[i], op410_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_3/conv2d_quant8_signed.js
+++ b/test/cts/test/V1_3/conv2d_quant8_signed.js
@@ -166,7 +166,7 @@ describe('CTS', function() {
     let type54_length = product(type54.dimensions);
     let type72 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [1, 2, 2, 1]};
     let type72_length = product(type72.dimensions);
-    let type73 = {type: nn.TENSOR_INT32, dimensions: [1]};
+    let type73 = {type: nn.TENSOR_INT32, dimensions: [1], scale: 0.0, zeroPoint: 0};
     let type73_length = product(type73.dimensions);
 
     let op17 = operandIndex++;
@@ -240,7 +240,7 @@ describe('CTS', function() {
     let type76_length = product(type76.dimensions);
     let type77 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [1, 3, 3, 1]};
     let type77_length = product(type77.dimensions);
-    let type78 = {type: nn.TENSOR_INT32, dimensions: [1]};
+    let type78 = {type: nn.TENSOR_INT32, dimensions: [1], scale: 0.0, zeroPoint: 0};
     let type78_length = product(type78.dimensions);
 
     let op18 = operandIndex++;
@@ -303,7 +303,7 @@ describe('CTS', function() {
     let type45_length = product(type45.dimensions);
     let type82 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 3]};
     let type82_length = product(type82.dimensions);
-    let type83 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type83 = {type: nn.TENSOR_INT32, dimensions: [3], scale: 0.0, zeroPoint: 0};
     let type83_length = product(type83.dimensions);
 
     let op19 = operandIndex++;
@@ -377,7 +377,7 @@ describe('CTS', function() {
     let type88_length = product(type88.dimensions);
     let type89 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 3]};
     let type89_length = product(type89.dimensions);
-    let type90 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type90 = {type: nn.TENSOR_INT32, dimensions: [3], scale: 0.0, zeroPoint: 0};
     let type90_length = product(type90.dimensions);
 
     let op110 = operandIndex++;
@@ -449,7 +449,7 @@ describe('CTS', function() {
     let type91_length = product(type91.dimensions);
     let type92 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [3, 1, 1, 3]};
     let type92_length = product(type92.dimensions);
-    let type93 = {type: nn.TENSOR_INT32, dimensions: [3]};
+    let type93 = {type: nn.TENSOR_INT32, dimensions: [3], scale: 0.0, zeroPoint: 0};
     let type93_length = product(type93.dimensions);
 
     let op110 = operandIndex++;

--- a/test/cts/test/V1_3/conv2d_quant8_signed.js
+++ b/test/cts/test/V1_3/conv2d_quant8_signed.js
@@ -442,7 +442,7 @@ describe('CTS', function() {
     let operandIndex = 0;
 
     let op110_value = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
-    let op410_expect = [29, 35, 41, 65, 80, 95, 101, 125, 149, 137, 170, 203, 173, 215, 257, 209, 260, 311];
+    let op410_expect = [29, 35, 41, 65, 80, 95, 101, 125, 127, 127, 127, 127, 127, 127, 127, 127, 127, 127];
 
     let type4 = {type: nn.INT32};
     let type91 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 3, 3], scale: 1.0, zeroPoint: -1};

--- a/test/cts/test/V1_3/depthwise_conv2d_quant8_signed.js
+++ b/test/cts/test/V1_3/depthwise_conv2d_quant8_signed.js
@@ -76,7 +76,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type13_length; ++i) {
-      assert.isTrue(almostEqualCTS(op45_output[i], op45_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op45_output[i], op45_expect[i]));
     }
   });
 
@@ -153,7 +153,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type17_length; ++i) {
-      assert.isTrue(almostEqualCTS(op46_output[i], op46_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op46_output[i], op46_expect[i]));
     }
   });
 
@@ -230,7 +230,7 @@ describe('CTS', function() {
     await execution.startCompute();
 
     for (let i = 0; i < type17_length; ++i) {
-      assert.isTrue(almostEqualCTS(op47_output[i], op47_expect[i]));
+      assert.isTrue(almostEqualCTSQuant8(op47_output[i], op47_expect[i]));
     }
   });
 });

--- a/test/cts/test/V1_3/depthwise_conv2d_quant8_signed.js
+++ b/test/cts/test/V1_3/depthwise_conv2d_quant8_signed.js
@@ -1,0 +1,236 @@
+// Generated file (from: depthwise_conv2d_quant8_signed.mod.py). Do not edit
+describe('CTS', function() {
+  const assert = chai.assert;
+  const nn = navigator.ml.getNeuralNetworkContext();
+
+  it('check result for Depthwise conv2d quant8 signed example-1', async function() {
+    // For 'Depthwise conv2d quant8 signed' example: examples_same
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op15_value = [-124, -112, -124, -96, -124, -64, -124, 0];
+    let op45_expect = [-120, -80];
+
+    let type10 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 2, 2], scale: 0.5, zeroPoint: -128};
+    let type10_length = product(type10.dimensions);
+    let type11 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [1, 2, 2, 2]};
+    let type11_length = product(type11.dimensions);
+    let type12 = {type: nn.TENSOR_INT32, dimensions: [2]};
+    let type12_length = product(type12.dimensions);
+    let type13 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 1, 1, 2], scale: 1.0, zeroPoint: -128};
+    let type13_length = product(type13.dimensions);
+    let type4 = {type: nn.INT32};
+
+    let op15 = operandIndex++;
+    model.addOperand(type10);
+    let op25 = operandIndex++;
+    model.addOperand(type11);
+    model.setOperandSymmPerChannelQuantParams(op25, {channelDim: 3, scales: new Float32Array([0.5, 0.5])});
+    let op35 = operandIndex++;
+    model.addOperand(type12);
+    let param41 = operandIndex++;
+    model.addOperand(type4);
+    let param42 = operandIndex++;
+    model.addOperand(type4);
+    let param43 = operandIndex++;
+    model.addOperand(type4);
+    let param44 = operandIndex++;
+    model.addOperand(type4);
+    let param45 = operandIndex++;
+    model.addOperand(type4);
+    let param46 = operandIndex++;
+    model.addOperand(type4);
+    let param47 = operandIndex++;
+    model.addOperand(type4);
+    let param48 = operandIndex++;
+    model.addOperand(type4);
+    let op45 = operandIndex++;
+    model.addOperand(type13);
+
+    model.setOperandValue(op25, new Int8Array([2, 4, 2, 0, 2, 2, 2, 0]));
+    model.setOperandValue(op35, new Int32Array([0, 0]));
+    model.setOperandValue(param41, new Int32Array([0]));
+    model.setOperandValue(param42, new Int32Array([0]));
+    model.setOperandValue(param43, new Int32Array([0]));
+    model.setOperandValue(param44, new Int32Array([0]));
+    model.setOperandValue(param45, new Int32Array([1]));
+    model.setOperandValue(param46, new Int32Array([1]));
+    model.setOperandValue(param47, new Int32Array([1]));
+    model.setOperandValue(param48, new Int32Array([0]));
+    model.addOperation(nn.DEPTHWISE_CONV_2D, [op15, op25, op35, param41, param42, param43, param44, param45, param46, param47, param48], [op45]);
+
+    model.identifyInputsAndOutputs([op15], [op45]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op15_input = new Int8Array(op15_value);
+    execution.setInput(0, op15_input);
+    let op45_output = new Int8Array(type13_length);
+    execution.setOutput(0, op45_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type13_length; ++i) {
+      assert.isTrue(almostEqualCTS(op45_output[i], op45_expect[i]));
+    }
+  });
+
+  it('check result for Depthwise conv2d quant8 signed example-2', async function() {
+    // For 'Depthwise conv2d quant8 signed' example: examples_different
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op16_value = [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2];
+    let op46_expect = [4, 2, 6, 3, 4, 2, 6, 3, 4, 2, 6, 3, 4, 2, 6, 3];
+
+    let type14 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 3, 2], scale: 0.5, zeroPoint: 0};
+    let type14_length = product(type14.dimensions);
+    let type15 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [1, 2, 2, 4]};
+    let type15_length = product(type15.dimensions);
+    let type16 = {type: nn.TENSOR_INT32, dimensions: [4]};
+    let type16_length = product(type16.dimensions);
+    let type17 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 2, 4], scale: 1.0, zeroPoint: 0};
+    let type17_length = product(type17.dimensions);
+    let type4 = {type: nn.INT32};
+
+    let op16 = operandIndex++;
+    model.addOperand(type14);
+    let op26 = operandIndex++;
+    model.addOperand(type15);
+    model.setOperandSymmPerChannelQuantParams(op26, {channelDim: 3, scales: new Float32Array([1.0, 0.5, 1.0, 0.5])});
+    let op36 = operandIndex++;
+    model.addOperand(type16);
+    let param49 = operandIndex++;
+    model.addOperand(type4);
+    let param50 = operandIndex++;
+    model.addOperand(type4);
+    let param51 = operandIndex++;
+    model.addOperand(type4);
+    let param52 = operandIndex++;
+    model.addOperand(type4);
+    let param53 = operandIndex++;
+    model.addOperand(type4);
+    let param54 = operandIndex++;
+    model.addOperand(type4);
+    let param55 = operandIndex++;
+    model.addOperand(type4);
+    let param56 = operandIndex++;
+    model.addOperand(type4);
+    let op46 = operandIndex++;
+    model.addOperand(type17);
+
+    model.setOperandValue(op26, new Int8Array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]));
+    model.setOperandValue(op36, new Int32Array([4, 4, 4, 4]));
+    model.setOperandValue(param49, new Int32Array([0]));
+    model.setOperandValue(param50, new Int32Array([0]));
+    model.setOperandValue(param51, new Int32Array([0]));
+    model.setOperandValue(param52, new Int32Array([0]));
+    model.setOperandValue(param53, new Int32Array([1]));
+    model.setOperandValue(param54, new Int32Array([1]));
+    model.setOperandValue(param55, new Int32Array([2]));
+    model.setOperandValue(param56, new Int32Array([0]));
+    model.addOperation(nn.DEPTHWISE_CONV_2D, [op16, op26, op36, param49, param50, param51, param52, param53, param54, param55, param56], [op46]);
+
+    model.identifyInputsAndOutputs([op16], [op46]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op16_input = new Int8Array(op16_value);
+    execution.setInput(0, op16_input);
+    let op46_output = new Int8Array(type17_length);
+    execution.setOutput(0, op46_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type17_length; ++i) {
+      assert.isTrue(almostEqualCTS(op46_output[i], op46_expect[i]));
+    }
+  });
+
+  it('check result for Depthwise conv2d quant8 signed example-3', async function() {
+    // For 'Depthwise conv2d quant8 signed' example: examples_layout_nhwc
+    let model = await nn.createModel(options);
+    let operandIndex = 0;
+
+    let op17_value = [1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2];
+    let op47_expect = [4, 2, 6, 3, 4, 2, 6, 3, 4, 2, 6, 3, 4, 2, 6, 3];
+
+    let type14 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 3, 3, 2], scale: 0.5, zeroPoint: 0};
+    let type14_length = product(type14.dimensions);
+    let type16 = {type: nn.TENSOR_INT32, dimensions: [4]};
+    let type16_length = product(type16.dimensions);
+    let type17 = {type: nn.TENSOR_QUANT8_ASYMM_SIGNED, dimensions: [1, 2, 2, 4], scale: 1.0, zeroPoint: 0};
+    let type17_length = product(type17.dimensions);
+    let type18 = {type: nn.TENSOR_QUANT8_SYMM_PER_CHANNEL, dimensions: [1, 2, 2, 4]};
+    let type18_length = product(type18.dimensions);
+    let type4 = {type: nn.INT32};
+
+    let op17 = operandIndex++;
+    model.addOperand(type14);
+    let op27 = operandIndex++;
+    model.addOperand(type18);
+    model.setOperandSymmPerChannelQuantParams(op27, {channelDim: 3, scales: new Float32Array([1.0, 0.5, 1.0, 0.5])});
+    let op37 = operandIndex++;
+    model.addOperand(type16);
+    let param57 = operandIndex++;
+    model.addOperand(type4);
+    let param58 = operandIndex++;
+    model.addOperand(type4);
+    let param59 = operandIndex++;
+    model.addOperand(type4);
+    let param60 = operandIndex++;
+    model.addOperand(type4);
+    let param61 = operandIndex++;
+    model.addOperand(type4);
+    let param62 = operandIndex++;
+    model.addOperand(type4);
+    let param63 = operandIndex++;
+    model.addOperand(type4);
+    let param64 = operandIndex++;
+    model.addOperand(type4);
+    let op47 = operandIndex++;
+    model.addOperand(type17);
+
+    model.setOperandValue(op27, new Int8Array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]));
+    model.setOperandValue(op37, new Int32Array([4, 4, 4, 4]));
+    model.setOperandValue(param57, new Int32Array([0]));
+    model.setOperandValue(param58, new Int32Array([0]));
+    model.setOperandValue(param59, new Int32Array([0]));
+    model.setOperandValue(param60, new Int32Array([0]));
+    model.setOperandValue(param61, new Int32Array([1]));
+    model.setOperandValue(param62, new Int32Array([1]));
+    model.setOperandValue(param63, new Int32Array([2]));
+    model.setOperandValue(param64, new Int32Array([0]));
+    model.addOperation(nn.DEPTHWISE_CONV_2D, [op17, op27, op37, param57, param58, param59, param60, param61, param62, param63, param64], [op47]);
+
+    model.identifyInputsAndOutputs([op17], [op47]);
+    await model.finish();
+
+    let compilation = await model.createCompilation();
+    compilation.setPreference(getPreferenceCode(options.prefer));
+    await compilation.finish();
+
+    let execution = await compilation.createExecution();
+
+    let op17_input = new Int8Array(op17_value);
+    execution.setInput(0, op17_input);
+    let op47_output = new Int8Array(type17_length);
+    execution.setOutput(0, op47_output);
+
+    await execution.startCompute();
+
+    for (let i = 0; i < type17_length; ++i) {
+      assert.isTrue(almostEqualCTS(op47_output[i], op47_expect[i]));
+    }
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,7 +3,9 @@ const assert = chai.assert;
 let options = {};
 const EPISILON = 1e-5;
 const EPISILON5ULP = 5.0 * 0.0009765625;
+const EPISILONQUANT8 = 1;
 let episilonCTS = EPISILON;
+let episilonCTSQuant8 = EPISILONQUANT8;
 // refer to https://android.googlesource.com/platform/frameworks/ml/+/master/nn/runtime/test/TestGenerated.cpp#117
 let rtol = 5.0 * 1.1920928955078125e-7;
 
@@ -11,7 +13,7 @@ function product(array) {
   return array.reduce((accumulator, currentValue) => accumulator * currentValue);
 }
 
-function almostEqual(a, b, episilon=1e-6) {
+function almostEqual(a, b, episilon=1e-6, rtol=5.0*1.1920928955078125e-7) {
   let delta = Math.abs(a - b);
   if (delta <= episilon + rtol * Math.abs(b)) {
     return true;
@@ -34,6 +36,10 @@ function almostEqualRM(a, b) {
 
 function almostEqualCTS(a, b) {
   return almostEqual(a, b, episilonCTS)
+}
+
+function almostEqualCTSQuant8(a, b) {
+  return almostEqual(a, b, episilonCTSQuant8, 0)
 }
 
 function setOptionsPerLayer() {
@@ -209,5 +215,3 @@ async function assertDoesNotThrowAsync(fn, regExp) {
     assert.doesNotThrow(f, regExp);
   }
 }
-
-


### PR DESCRIPTION
Add 10 CTS test cases for "CONV_2D" and "DEPTHWISE_CONV_2D" ops with `TENSOR_QUANT8_ASYMM_SIGNED` input and `TENSOR_QUANT8_SYMM_PER_CHANNEL` weights. 

op | cts | plus | supplement
-- | -- | -- | --
CONV_2D | 7 | 0 | 0
DEPTHWISE_CONV_2D | 3 | 0 | 0

fixes #1178
Signed-off-by: cuiyanx <yanx.cui@intel.com>