### PR TITLE
[tool] Update CTSConverter to support new ops

### DIFF
--- a/test/cts/tool/CTSConverter/slice.json
+++ b/test/cts/tool/CTSConverter/slice.json
@@ -149,5 +149,11 @@
         "softmax_v1_2.mod.py",
         "transpose_float16.mod.py",
         "transpose_v1_2.mod.py"
+    ],
+    "V1_3": [
+      "avg_pool_quant8_signed.mod.py",
+      "conv2d_quant8_signed.mod.py",
+      "depthwise_conv2d_quant8_signed.mod.py",
+      "softmax_quant8_signed.mod.py"
     ]
 }

--- a/test/cts/tool/CTSConverter/src/nn/specs/V1_3/avg_pool_quant8_signed.mod.py
+++ b/test/cts/tool/CTSConverter/src/nn/specs/V1_3/avg_pool_quant8_signed.mod.py
@@ -1,0 +1,349 @@
+#
+# Copyright (C) 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 0.5f, -128")
+cons1 = Int32Scalar("cons1", 1)
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+o = Output("op3", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 0.5f, -128")
+model = model.Operation("AVERAGE_POOL_2D", i1, pad0, pad0, pad0, pad0, cons1, cons1, cons1, cons1, act).To(o)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-127, -126, -125, -124]}
+
+output0 = {o: # output 0
+          [-127, -126, -125, -124]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+
+bat = 5
+row = 52
+col = 60
+chn = 3
+
+i0 = Input("i0", "TENSOR_QUANT8_ASYMM_SIGNED", "{%d, %d, %d, %d}, 0.5f, -128" % (bat, row, col, chn))
+
+std = 5
+flt = 10
+pad = 5
+
+stride = Int32Scalar("stride", std)
+filt = Int32Scalar("filter", flt)
+padding = Int32Scalar("padding", pad)
+act0 = Int32Scalar("activation", 0)
+output_row = (row + 2 * pad - flt + std) // std
+output_col = (col + 2 * pad - flt + std) // std
+
+output = Output("output", "TENSOR_QUANT8_ASYMM_SIGNED",
+                "{%d, %d, %d, %d}, 0.5f, -128" % (bat, output_row, output_col, chn))
+
+model = model.Operation(
+    "AVERAGE_POOL_2D", i0, padding, padding, padding, padding, stride, stride, filt, filt, act0).To(output)
+
+# Example 1. Input in operand 0,
+input_values = [127 for _ in range(bat * row * col * chn)]
+input0 = {i0: input_values}
+output_values = [127 for _ in range(bat * output_row * output_col * chn)]
+output0 = {output: output_values}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+
+bat = 1
+row = 100
+col = 100
+chn = 1
+
+i0 = Input("i0", "TENSOR_QUANT8_ASYMM_SIGNED", "{%d, %d, %d, %d}, 0.5f, -128" % (bat, row, col, chn))
+
+std = 4
+flt = 10
+pad = 0
+
+stride = Int32Scalar("stride", std)
+filt = Int32Scalar("filter", flt)
+padding = Int32Scalar("padding", pad)
+act0 = Int32Scalar("activation", 0)
+output_row = (row + 2 * pad - flt + std) // std
+output_col = (col + 2 * pad - flt + std) // std
+
+output = Output("output", "TENSOR_QUANT8_ASYMM_SIGNED",
+                "{%d, %d, %d, %d}, 0.5f, -128" % (bat, output_row, output_col, chn))
+
+model = model.Operation(
+    "AVERAGE_POOL_2D", i0, padding, padding, padding, padding, stride, stride, filt, filt, act0).To(output)
+
+# Example 1. Input in operand 0,
+input_values = [x % 4 * 2 - 128 for x in range(bat * row * col * chn)]
+input0 = {i0: input_values}
+output_values = [-125 for _ in range(bat * output_row * output_col * chn)]
+output0 = {output: output_values}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 3, 1}, 0.5f, -128")
+cons1 = Int32Scalar("cons1", 1)
+pad0 = Int32Scalar("pad0", 0)
+act2 = Int32Scalar("relu1_activitation", 2)
+o = Output("op3", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 3, 1}, 0.5f, -128")
+model = model.Operation("AVERAGE_POOL_2D", i1, pad0, pad0, pad0, pad0, cons1, cons1, cons1, cons1, act2).To(o)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-128, -127, -126, -125, -124, -123, -122, -121, -120]}
+
+output0 = {o: # output 0
+          [-128, -127, -126, -126, -126, -126, -126, -126, -126]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 4, 1}, 0.0625f, -128") # input 0
+cons2 = Int32Scalar("cons2", 2)
+pad_same = Int32Scalar("pad_same", 1)
+act_none = Int32Scalar("act_none", 0)
+i3 = Output("op3", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 2, 1}, 0.0625f, -128") # output 0
+model = model.Operation("AVERAGE_POOL_2D", i1, pad_same, cons2, cons2, cons2, cons2, act_none).To(i3)
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-128, -32, -96, -64, -80, -96, 32, -16]}
+output0 = {i3: # output 0
+          [-84, -36]}
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+layout = BoolScalar("layout", False) # NHWC
+
+# TEST 1: AVERAGE_POOL_2D_NCHW_1, pad = 0, stride = 1, filter = 1, act = none
+i1 = Input("op1", "TENSOR_FLOAT32", "{1, 2, 2, 1}")
+o1 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 1}")
+Model().Operation("AVERAGE_POOL_2D", i1, 0, 0, 0, 0, 1, 1, 1, 1, 0, layout).To(o1)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i1: [1.0, 2.0, 3.0, 4.0],
+    o1: [1.0, 2.0, 3.0, 4.0]
+}).AddNchw(i1, o1, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# TEST 2: AVERAGE_POOL_2D_NCHW_2, act = none
+bat = 5
+row = 52
+col = 60
+chn = 3
+std = 5
+flt = 100
+pad = 50
+output_row = (row + 2 * pad - flt + std) // std
+output_col = (col + 2 * pad - flt + std) // std
+
+i2 = Input("op1", ("TENSOR_FLOAT32", [bat, row, col, chn]))
+o2 = Output("op4", ("TENSOR_FLOAT32", [bat, output_row, output_col, chn]))
+Model().Operation("AVERAGE_POOL_2D", i2, pad, pad, pad, pad, std, std, flt, flt, 0, layout).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [1. for _ in range(bat * row * col * chn)],
+    o2: [1. for _ in range(bat * output_row * output_col * chn)]
+}).AddNchw(i2, o2, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# TEST 3: AVERAGE_POOL_2D_NCHW_3, act = none
+bat = 1
+row = 200
+col = 180
+chn = 1
+std = 2
+flt = 10
+pad = 0
+output_row = (row + 2 * pad - flt + std) // std
+output_col = (col + 2 * pad - flt + std) // std
+
+i3 = Input("op1", ("TENSOR_FLOAT32", [bat, row, col, chn]))
+o3 = Output("op4", ("TENSOR_FLOAT32", [bat, output_row, output_col, chn]))
+Model().Operation("AVERAGE_POOL_2D", i3, pad, pad, pad, pad, std, std, flt, flt, 0, layout).To(o3)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.25, -128),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.25, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i3: [x % 2 for x in range(bat * row * col * chn)],
+    o3: [.5 for _ in range(bat * output_row * output_col * chn)]
+}).AddNchw(i3, o3, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# TEST 4: AVERAGE_POOL_2D_NCHW_4, act = relu6
+bat = 5
+row = 52
+col = 60
+chn = 3
+std = 5
+flt = 100
+pad = 50
+output_row = (row + 2 * pad - flt + std) // std
+output_col = (col + 2 * pad - flt + std) // std
+
+i4 = Input("op1", ("TENSOR_FLOAT32", [bat, row, col, chn]))
+o4 = Output("op4", ("TENSOR_FLOAT32", [bat, output_row, output_col, chn]))
+Model().Operation("AVERAGE_POOL_2D", i4, pad, pad, pad, pad, std, std, flt, flt, 3, layout).To(o4)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    o4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i4: [10 for _ in range(bat * row * col * chn)],
+    o4: [6 for _ in range(bat * output_row * output_col * chn)]
+}).AddNchw(i4, o4, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# TEST 5: AVERAGE_POOL_2D_NCHW_5, pad = same, stride = 2, filter = 2, act = none
+i5 = Input("op1", "TENSOR_FLOAT32", "{1, 2, 4, 1}")
+o5 = Output("op4", "TENSOR_FLOAT32", "{1, 1, 2, 1}")
+Model().Operation("AVERAGE_POOL_2D", i5, 1, 2, 2, 2, 2, 0, layout).To(o5)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i5: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.25, -128),
+    o5: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.25, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i5: [0, 6, 2, 4, 3, 2, 10, 7],
+    o5: [2.75, 5.75]
+}).AddNchw(i5, o5, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# TEST 6: zero-sized input, explicit padding
+
+# Use BOX_WITH_NMS_LIMIT op to generate a zero-sized internal tensor for box cooridnates.
+p1 = Parameter("scores", "TENSOR_FLOAT32", "{1, 2}", [0.90, 0.10]) # scores
+p2 = Parameter("roi", "TENSOR_FLOAT32", "{1, 8}", [1, 1, 10, 10, 0, 0, 10, 10]) # roi
+o1 = Output("scoresOut", "TENSOR_FLOAT32", "{0}") # scores out
+o2 = Output("classesOut", "TENSOR_INT32", "{0}") # classes out
+tmp1 = Internal("roiOut", "TENSOR_FLOAT32", "{0, 4}") # roi out
+tmp2 = Internal("batchSplitOut", "TENSOR_INT32", "{0}") # batch split out
+model = Model("zero_sized").Operation("BOX_WITH_NMS_LIMIT", p1, p2, [0], 0.3, -1, 0, 0.4, 1.0, 0.3).To(o1, tmp1, o2, tmp2)
+
+# Use ROI_ALIGN op to convert into zero-sized feature map.
+i1 = Input("in", "TENSOR_FLOAT32", "{1, 1, 1, 1}")
+zero_sized = Internal("featureMap", "TENSOR_FLOAT32", "{0, 2, 2, 1}")
+model = model.Operation("ROI_ALIGN", i1, tmp1, tmp2, 2, 2, 2.0, 2.0, 4, 4, layout).To(zero_sized)
+
+# AVERAGE_POOL_2D op with numBatches = 0.
+o3 = Output("out", "TENSOR_FLOAT32", "{0, 1, 1, 1}") # out
+model = model.Operation("AVERAGE_POOL_2D", zero_sized, 0, 0, 0, 0, 1, 1, 2, 2, 0, layout).To(o3)
+
+quant8_signed = DataTypeConverter().Identify({
+    p1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    p2: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    tmp1: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    zero_sized: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0)
+})
+
+Example({
+    i1: [1],
+    o1: [],
+    o2: [],
+    o3: [],
+}).AddNchw(i1, zero_sized, o3, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# TEST 7: zero-sized input, implicit padding
+
+# Use BOX_WITH_NMS_LIMIT op to generate a zero-sized internal tensor for box cooridnates.
+p1 = Parameter("scores", "TENSOR_FLOAT32", "{1, 2}", [0.90, 0.10]) # scores
+p2 = Parameter("roi", "TENSOR_FLOAT32", "{1, 8}", [1, 1, 10, 10, 0, 0, 10, 10]) # roi
+o1 = Output("scoresOut", "TENSOR_FLOAT32", "{0}") # scores out
+o2 = Output("classesOut", "TENSOR_INT32", "{0}") # classes out
+tmp1 = Internal("roiOut", "TENSOR_FLOAT32", "{0, 4}") # roi out
+tmp2 = Internal("batchSplitOut", "TENSOR_INT32", "{0}") # batch split out
+model = Model("zero_sized").Operation("BOX_WITH_NMS_LIMIT", p1, p2, [0], 0.3, -1, 0, 0.4, 1.0, 0.3).To(o1, tmp1, o2, tmp2)
+
+# Use ROI_ALIGN op to convert into zero-sized feature map.
+i1 = Input("in", "TENSOR_FLOAT32", "{1, 1, 1, 1}")
+zero_sized = Internal("featureMap", "TENSOR_FLOAT32", "{0, 2, 2, 1}")
+model = model.Operation("ROI_ALIGN", i1, tmp1, tmp2, 2, 2, 2.0, 2.0, 4, 4, layout).To(zero_sized)
+
+# AVERAGE_POOL_2D op with numBatches = 0.
+o3 = Output("out", "TENSOR_FLOAT32", "{0, 2, 2, 1}") # out
+model = model.Operation("AVERAGE_POOL_2D", zero_sized, 1, 1, 1, 2, 2, 0, layout).To(o3)
+
+quant8_signed = DataTypeConverter().Identify({
+    p1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    p2: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    tmp1: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    zero_sized: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0)
+})
+
+Example({
+    i1: [1],
+    o1: [],
+    o2: [],
+    o3: [],
+}).AddNchw(i1, zero_sized, o3, layout).AddVariations(quant8_signed, includeDefault=False)

--- a/test/cts/tool/CTSConverter/src/nn/specs/V1_3/conv2d_quant8_signed.mod.py
+++ b/test/cts/tool/CTSConverter/src/nn/specs/V1_3/conv2d_quant8_signed.mod.py
@@ -1,0 +1,661 @@
+#
+# Copyright (C) 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+layout = BoolScalar("layout", False) # NHWC
+
+# dilation set to 1 (default)
+i1 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 3, 1}")
+f1 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 1}", [.25, .25, .25, .25])
+b1 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [0])
+o1 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 1}")
+Model().Operation("CONV_2D", i1, f1, b1, 0, 0, 0, 0, 1, 1, 0, layout, 1, 1).To(o1)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b1: ("TENSOR_INT32", 0.0625, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i1: [1.0, 1.0, 1.0, 1.0, 0.5, 1.0, 1.0, 1.0, 1.0],
+    o1: [.875, .875, .875, .875]
+}).AddNchw(i1, o1, layout).AddVariations(quant8_signed, includeDefault=False)
+
+
+# dilation set to 3
+i2 = Input("op1", "TENSOR_FLOAT32", "{1, 9, 9, 1}")
+f2 = Parameter("op2", "TENSOR_FLOAT32", "{1, 3, 3, 1}", [1, 2, 3, 4, 5, 6, 7, 8, 9])
+b2 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [0])
+o2 = Output("op4", "TENSOR_FLOAT32", "{1, 3, 3, 1}")
+Model().Operation("CONV_2D", i2, f2, b2, 0, 0, 0, 0, 1, 1, 0, layout, 3, 3).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b2: ("TENSOR_INT32", 0.0625, 0),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 1, 1, 1, 0, 0, 0,
+         0, 0, 0, 1, 1, 1, 0, 0, 0,
+         0, 0, 0, 1, 1, 1, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0],
+    o2: [5, 5, 5, 5, 5, 5, 5, 5, 5]
+}).AddNchw(i2, o2, layout).AddVariations(quant8_signed, includeDefault=False)
+
+# same as test 1 but with implicit VALID padding
+i1 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 3, 1}")
+f1 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 1}", [.25, .25, .25, .25])
+b1 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [0])
+o1 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 1}")
+Model().Operation("CONV_2D", i1, f1, b1, 2, 1, 1, 0, layout, 1, 1).To(o1)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b1: ("TENSOR_INT32", 0.0625, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i1: [1.0, 1.0, 1.0, 1.0, 0.5, 1.0, 1.0, 1.0, 1.0],
+    o1: [.875, .875, .875, .875]
+}, name="valid_padding").AddNchw(i1, o1, layout).AddVariations(quant8_signed, includeDefault=False)
+
+
+# same as test 2 but with implicit VALID padding
+i2 = Input("op1", "TENSOR_FLOAT32", "{1, 9, 9, 1}")
+f2 = Parameter("op2", "TENSOR_FLOAT32", "{1, 3, 3, 1}", [1, 2, 3, 4, 5, 6, 7, 8, 9])
+b2 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [0])
+o2 = Output("op4", "TENSOR_FLOAT32", "{1, 3, 3, 1}")
+Model().Operation("CONV_2D", i2, f2, b2, 2, 1, 1, 0, layout, 3, 3).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b2: ("TENSOR_INT32", 0.0625, 0),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 1, 1, 1, 0, 0, 0,
+         0, 0, 0, 1, 1, 1, 0, 0, 0,
+         0, 0, 0, 1, 1, 1, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0, 0],
+    o2: [5, 5, 5, 5, 5, 5, 5, 5, 5]
+}, name="valid_padding").AddNchw(i2, o2, layout).AddVariations(quant8_signed, includeDefault=False)
+
+
+# dilation set to 3, SAME padding
+i3 = Input("op1", "TENSOR_FLOAT32", "{1, 6, 6, 1}")
+f3 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 1}", [1, 2, 3, 4])
+b3 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [0])
+o3 = Output("op4", "TENSOR_FLOAT32", "{1, 3, 3, 1}")
+Model().Operation("CONV_2D", i3, f3, b3, 1, 2, 2, 0, layout, 3, 3).To(o3)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b3: ("TENSOR_INT32", 0.0625, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i3: [0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0,
+         0, 0, 4, 3, 0, 0,
+         0, 0, 2, 1, 0, 0,
+         0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0],
+    o3: [16, 0, 9, 0, 0, 0, 4, 0, 1]
+}).AddNchw(i3, o3, layout).AddVariations(quant8_signed, includeDefault=False)
+
+# No layout param specified
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 1, 2}, 0.5f, 0")
+f1 = Parameter("op2", "TENSOR_QUANT8_SYMM_PER_CHANNEL", "{3, 1, 1, 2}",
+               [1, 2, 1, 2, 1, 2], extraParams = SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 0.75, 1.0]))
+b1 = Parameter("op3", "TENSOR_INT32", "{3}", [4, 4, 4])
+o1 = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 1, 3}, 1.f, 0")
+Model().Operation("CONV_2D", i1, f1, b1, 0, 0, 0, 0, 1, 1, 0).To(o1)
+
+# Instantiate an example
+Example({
+    i1: [10, 10, 10, 10, 10, 10],
+    o1: [9, 13, 17, 9, 13, 17, 9, 13, 17]
+})
+
+# layout param, NHWC/NCHW layouts
+layout = BoolScalar("layout", False) # NHWC
+i2 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 1, 2}, 0.5f, 0")
+f2 = Parameter("op2", "TENSOR_QUANT8_SYMM_PER_CHANNEL", "{3, 1, 1, 2}",
+               [1, 2, 1, 2, 1, 2], extraParams = SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 0.75, 1.0]))
+b2 = Parameter("op3", "TENSOR_INT32", "{3}", [4, 4, 4])
+o2 = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 1, 3}, 1.f, 0")
+Model("layouts").Operation("CONV_2D", i2, f2, b2, 0, 0, 0, 0, 1, 1, 0, layout).To(o2)
+
+# Instantiate an example
+Example({
+    i2: [10, -20, 10, -20, 10, -20],
+    o2: [-7, -10, -13, -7, -10, -13, -7, -10, -13]
+}).AddNchw(i2, o2, layout)
+
+# zero-sized input
+
+# Use BOX_WITH_NMS_LIMIT op to generate a zero-sized internal tensor for box cooridnates.
+p1 = Parameter("scores", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2}, 0.1f, 0", [9, 1]) # scores
+p2 = Parameter("roi", "TENSOR_QUANT16_ASYMM", "{1, 8}, 0.125f, 0", [1, 1, 10, 10, 0, 0, 10, 10]) # roi
+o1 = Output("scoresOut", "TENSOR_QUANT8_ASYMM_SIGNED", "{0}, 0.1f, 0") # scores out
+o2 = Output("classesOut", "TENSOR_INT32", "{0}") # classes out
+tmp1 = Internal("roiOut", "TENSOR_QUANT16_ASYMM", "{0, 4}, 0.125f, 0") # roi out
+tmp2 = Internal("batchSplitOut", "TENSOR_INT32", "{0}") # batch split out
+model = Model("zero_sized").Operation("BOX_WITH_NMS_LIMIT", p1, p2, [0], 0.3, -1, 0, 0.4, 1.0, 0.3).To(o1, tmp1, o2, tmp2)
+
+# Use ROI_ALIGN op to convert into zero-sized feature map.
+i1 = Input("in", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 2}, 0.5f, 0")
+zero_sized = Internal("featureMap", "TENSOR_QUANT8_ASYMM_SIGNED", "{0, 2, 2, 2}, 0.5f, 0")
+model = model.Operation("ROI_ALIGN", i1, tmp1, tmp2, 2, 2, 2.0, 2.0, 4, 4, layout).To(zero_sized)
+
+# CONV_2D op with numBatches = 0.
+w = Parameter("weights", "TENSOR_QUANT8_SYMM_PER_CHANNEL", "{3, 1, 1, 2}",
+              [1, 2, 1, 2, 1, 2], extraParams = SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 0.75, 1.0]))
+b = Parameter("bias", "TENSOR_INT32", "{3}", [4, 4, 4])
+o3 = Output("out", "TENSOR_QUANT8_ASYMM_SIGNED", "{0, 2, 2, 3}, 1.f, 0") # out
+model = model.Operation("CONV_2D", zero_sized, w, b, 0, 0, 0, 0, 1, 1, 0, layout).To(o3)
+
+Example({
+    i1: [2, 2],
+    o1: [],
+    o2: [],
+    o3: [],
+}).AddNchw(i1, zero_sized, o3, layout)
+
+layout = BoolScalar("layout", False) # NHWC
+
+# CONV_NCHW_1
+i1 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 3, 1}")
+f1 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 1}", [.25, .25, .25, .25])
+b1 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [0])
+o1 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 1}")
+Model().Operation("CONV_2D", i1, f1, b1, 0, 0, 0, 0, 1, 1, 0, layout).To(o1)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b1: ("TENSOR_INT32", 0.0625, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.125])),
+    b1: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.0625], hide=True)),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i1: [1.0, 1.0, 1.0, 1.0, 0.5, 1.0, 1.0, 1.0, 1.0],
+    o1: [.875, .875, .875, .875]
+}).AddNchw(i1, o1, layout).AddVariations(quant8_signed, channelquant8_signed, includeDefault=False)
+
+
+# CONV_NCHW_2
+i2 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 4, 1}")
+f2 = Parameter("op2", "TENSOR_FLOAT32", "{1, 3, 3, 1}", [1, 4, 7, 2, 5, 8, 3, 6, 9])
+b2 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [-200])
+o2 = Output("op4", "TENSOR_FLOAT32", "{1, 3, 4, 1}")
+Model().Operation("CONV_2D", i2, f2, b2, 1, 1, 1, 1, layout).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -1),
+    f2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -1),
+    b2: ("TENSOR_INT32", 0.25, 0),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 1.0, -78)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -1),
+    f2: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.5])),
+    b2: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.25], hide=True)),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 1.0, -78)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    o2: [0, 0, 0, 0, 35, 112, 157, 0, 0, 34, 61, 0]
+}).AddNchw(i2, o2, layout).AddVariations(quant8_signed, channelquant8_signed, includeDefault=False)
+
+
+# CONV_NCHW_CHANNEL
+i3 = Input("op1", "TENSOR_FLOAT32", "{1, 1, 1, 3}")
+f3 = Parameter("op2", "TENSOR_FLOAT32", "{3, 1, 1, 3}", [0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5])
+b3 = Parameter("op3", "TENSOR_FLOAT32", "{3}", [0., 0., 0.])
+o3 = Output("op4", "TENSOR_FLOAT32", "{1, 1, 1, 3}")
+Model("channel").Operation("CONV_2D", i3, f3, b3, 0, 0, 0, 0, 1, 1, 0, layout).To(o3)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    b3: ("TENSOR_INT32", 0.25, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f3: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 0.4, 0.3])),
+    b3: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.25, 0.2, 0.15], hide=True)),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i3: [5.,  5.,   5.],
+    o3: [15., 37.5, 60.]
+}).AddNchw(i3, o3, layout).AddVariations(quant8_signed, channelquant8_signed, includeDefault=False)
+
+
+# CONV_NCHW_LARGE
+i4 = Input("op1", "TENSOR_FLOAT32", "{1, 2, 3, 3}")
+f4 = Parameter("op2", "TENSOR_FLOAT32", "{3, 1, 1, 3}", [1., 4., 7., 2., 5., 8., 3., 6., 9.])
+b4 = Parameter("op3", "TENSOR_FLOAT32", "{3}", [0., 0., 0.])
+o4 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 3, 3}")
+Model("large").Operation("CONV_2D", i4, f4, b4, 0, 0, 0, 0, 1, 1, 0, layout).To(o4)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    f4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    b4: ("TENSOR_INT32", 0.25, 0),
+    o4: ("TENSOR_QUANT8_ASYMM_SIGNED", 2.0, -128)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    f4: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 1.0, 0.5])),
+    b4: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.25, 0.5, 0.25], hide=True)),
+    o4: ("TENSOR_QUANT8_ASYMM_SIGNED", 2.0, -128)
+})
+channelQuant8_mult_gt_1 = DataTypeConverter().Identify({
+    i4: ("TENSOR_QUANT8_ASYMM_SIGNED", 1.0, -1),
+    f4: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 1.0, 1.005])),
+    b4: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 1.0, 1.005], hide=True)),
+    o4: ("TENSOR_QUANT8_ASYMM_SIGNED", 1.0, -1)
+})
+
+# Instantiate an example
+example = Example({
+    i4: [1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,
+         10.,  11.,  12.,  13.,  14.,  15.,  16.,  17.,  18.],
+    o4: [30.,   36.,   42.,
+         66.,   81.,   96.,
+         102.,  126.,  150.,
+         138.,  171.,  204.,
+         174.,  216.,  258.,
+         210.,  261.,  312.]
+}).AddNchw(i4, o4, layout).AddVariations(quant8_signed, channelquant8_signed, channelQuant8_mult_gt_1, includeDefault=False)
+
+# quantized with scale product greater than output scale
+scale = 256.5 / 255
+zero_point = 0
+i9 = Input("op1", ("TENSOR_QUANT8_ASYMM_SIGNED", [2, 2, 4, 1], scale, zero_point))
+f9 = Parameter("op2", ("TENSOR_QUANT8_ASYMM_SIGNED", [3, 2, 2, 1], scale, zero_point),
+               [1, 2, 3, 4, -1, 1, -1, 1, -1, -1, 1, 1])
+b9 = Parameter("op3", ("TENSOR_INT32", [3], scale * scale, 0), [1, 2, 3])
+o9 = Output("op4", ("TENSOR_QUANT8_ASYMM_SIGNED", [2, 1, 2, 3], 1.0, -1))
+model9 = Model("quant_output_multiplier_gt_1").Operation("CONV_2D", i9, f9, b9, 2, 2, 2, 0).To(o9)
+
+# Instantiate an example
+example = Example({
+    i9: [
+        1, 1, 1, 1, 2, 2, 2, 2, 1, 2, 3, 4, 1, 2,
+        3, 4
+    ],
+    o9: [17, 1, 4, 17, 1, 4, 16, 3, 2, 36, 3, 2]
+}, model=model9)
+
+
+# zero-sized input, explicit padding
+
+# Use BOX_WITH_NMS_LIMIT op to generate a zero-sized internal tensor for box cooridnates.
+p1 = Parameter("scores", "TENSOR_FLOAT32", "{1, 2}", [0.90, 0.10]) # scores
+p2 = Parameter("roi", "TENSOR_FLOAT32", "{1, 8}", [1, 1, 10, 10, 0, 0, 10, 10]) # roi
+o1 = Output("scoresOut", "TENSOR_FLOAT32", "{0}") # scores out
+o2 = Output("classesOut", "TENSOR_INT32", "{0}") # classes out
+tmp1 = Internal("roiOut", "TENSOR_FLOAT32", "{0, 4}") # roi out
+tmp2 = Internal("batchSplitOut", "TENSOR_INT32", "{0}") # batch split out
+model = Model("zero_sized").Operation("BOX_WITH_NMS_LIMIT", p1, p2, [0], 0.3, -1, 0, 0.4, 1.0, 0.3).To(o1, tmp1, o2, tmp2)
+
+# Use ROI_ALIGN op to convert into zero-sized feature map.
+i1 = Input("in", "TENSOR_FLOAT32", "{1, 1, 1, 1}")
+zero_sized = Internal("featureMap", "TENSOR_FLOAT32", "{0, 2, 2, 1}")
+model = model.Operation("ROI_ALIGN", i1, tmp1, tmp2, 2, 2, 2.0, 2.0, 4, 4, layout).To(zero_sized)
+
+# CONV_2D op with numBatches = 0.
+w = Parameter("weights", "TENSOR_FLOAT32", "{2, 1, 1, 1}", [3, 4]) # weights
+b = Parameter("bias", "TENSOR_FLOAT32", "{2}", [1, 2]) # bias
+o3 = Output("out", "TENSOR_FLOAT32", "{0, 2, 2, 2}") # out
+model = model.Operation("CONV_2D", zero_sized, w, b, 0, 0, 0, 0, 1, 1, 0, layout).To(o3)
+
+quant8_signed = DataTypeConverter().Identify({
+    p1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    p2: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    tmp1: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    zero_sized: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    w: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    b: ("TENSOR_INT32", 0.01, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0)
+})
+
+Example({
+    i1: [1],
+    o1: [],
+    o2: [],
+    o3: [],
+}).AddNchw(i1, zero_sized, o3, layout).AddVariations(quant8_signed, includeDefault=False)
+
+
+# zero-sized input, implicit padding
+
+# Use BOX_WITH_NMS_LIMIT op to generate a zero-sized internal tensor for box cooridnates.
+p1 = Parameter("scores", "TENSOR_FLOAT32", "{1, 2}", [0.90, 0.10]) # scores
+p2 = Parameter("roi", "TENSOR_FLOAT32", "{1, 8}", [1, 1, 10, 10, 0, 0, 10, 10]) # roi
+o1 = Output("scoresOut", "TENSOR_FLOAT32", "{0}") # scores out
+o2 = Output("classesOut", "TENSOR_INT32", "{0}") # classes out
+tmp1 = Internal("roiOut", "TENSOR_FLOAT32", "{0, 4}") # roi out
+tmp2 = Internal("batchSplitOut", "TENSOR_INT32", "{0}") # batch split out
+model = Model("zero_sized").Operation("BOX_WITH_NMS_LIMIT", p1, p2, [0], 0.3, -1, 0, 0.4, 1.0, 0.3).To(o1, tmp1, o2, tmp2)
+
+# Use ROI_ALIGN op to convert into zero-sized feature map.
+i1 = Input("in", "TENSOR_FLOAT32", "{1, 1, 1, 1}")
+zero_sized = Internal("featureMap", "TENSOR_FLOAT32", "{0, 2, 2, 1}")
+model = model.Operation("ROI_ALIGN", i1, tmp1, tmp2, 2, 2, 2.0, 2.0, 4, 4, layout).To(zero_sized)
+
+# CONV_2D op with numBatches = 0.
+w = Parameter("weights", "TENSOR_FLOAT32", "{2, 1, 1, 1}", [3, 4]) # weights
+b = Parameter("bias", "TENSOR_FLOAT32", "{2}", [1, 2]) # bias
+o3 = Output("out", "TENSOR_FLOAT32", "{0, 2, 2, 2}") # out
+model = model.Operation("CONV_2D", zero_sized, w, b, 1, 1, 1, 0, layout).To(o3)
+
+quant8_signed = DataTypeConverter().Identify({
+    p1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    p2: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    tmp1: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    zero_sized: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    w: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    b: ("TENSOR_INT32", 0.01, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0)
+})
+
+Example({
+    i1: [1],
+    o1: [],
+    o2: [],
+    o3: [],
+}).AddNchw(i1, zero_sized, o3, layout).AddVariations(quant8_signed, includeDefault=False)
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 6, 1}, 0.5f, -1")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 0.5f, -1",
+               [1, 3, 5, 7])
+b1 = Parameter("op3", "TENSOR_INT32", "{1}, 0.25f, 0", [-4])
+pad_valid = Int32Scalar("pad_valid", 2)
+act_none = Int32Scalar("act_none", 0)
+stride1 = Int32Scalar("stride1", 1)
+stride3 = Int32Scalar("stride3", 3)
+
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 1.f, -1")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad_valid, stride3,
+                        stride1, act_none).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {
+    i1:  # input 0
+        [5, 3, 1, -3, -5, -7,
+         7, 5, 3, -5, -7, -9,
+         9, 7, 5, -7, -9, -11]
+}
+
+output0 = {
+    output:  # output 0
+        [29, -25, 39, -35]
+}
+
+# Instantiate an example
+Example((input0, output0))
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 3}, 0.5f, -128")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{3, 1, 1, 3}, 0.5f, -128", [-127, -126, -125, -124, -123, -122, -121, -120, -119])
+b1 = Parameter("op3", "TENSOR_INT32", "{3}, 0.25, 0", [0, 0, 0])
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 3}, 1.0, -128")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad0, pad0, pad0, pad0, stride, stride, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-118, -118, -118]}
+
+output0 = {output: # output 0
+           [-113, -90, -68]}
+
+# Instantiate an example
+Example((input0, output0))
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 3}, 0.5f, -128")
+f1 = Input("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{3, 1, 1, 3}, 0.5f, -128")
+b1 = Input("op3", "TENSOR_INT32", "{3}, 0.25, 0")
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 3}, 1.0, -128")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad0, pad0, pad0, pad0, stride, stride, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-118, -118, -118],
+          f1:
+          [-127, -126, -125,
+           -124, -123, -122,
+           -121, -120, -119],
+          b1:
+          [0, 0, 0]}
+
+output0 = {output: # output 0
+           [-113, -90, -68]}
+
+# Instantiate an example
+Example((input0, output0))
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 3, 3}, 0.5, -128")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{3, 1, 1, 3}, 0.5, -128", [-127, -124, -121, -126, -123, -120, -125, -122, -119])
+b1 = Parameter("op3", "TENSOR_INT32", "{3}, 0.25, 0", [0, 0, 0])
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+output = Output("op4",  "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 3, 3}, 1.0, -128")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad0, pad0, pad0, pad0, stride, stride, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [  -127,   -126,   -125,   -124,   -123,   -122,   -121,   -120,   -119,
+            -118,  -117,  -116,  -115,  -114,  -113,  -112,  -111,  -110]}
+
+output0 = {output: # output 0
+           [  -120,   -119,   -117,
+              -111,  -107,  -104,
+              -102,  -96,  -90,
+              -93,  -85,  -77,
+              -84,  -74,  -63,
+              -75,  -62,  -50]
+          }
+
+# Instantiate an example
+Example((input0, output0))
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 3, 3}, 0.5, -128")
+f1 = Input("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{3, 1, 1, 3}, 0.5, -128")
+b1 = Input("op3", "TENSOR_INT32", "{3}, 0.25, 0")
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+output = Output("op4",  "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 3, 3}, 1.0, -128")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad0, pad0, pad0, pad0, stride, stride, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [  -127,   -126,   -125,   -124,   -123,   -122,   -121,   -120,   -119,
+             -118,  -117,  -116,  -115,  -114,  -113,  -112,  -111,  -110],
+          f1:
+          [ -127,  -124,  -121,
+            -126,  -123,  -120,
+            -125,  -122,  -119],
+          b1:
+          [0, 0, 0]}
+
+output0 = {output: # output 0
+           [  -120,   -119,   -117,
+              -111,  -107,  -104,
+              -102,  -96,  -90,
+              -93,  -85,  -77,
+              -84,  -74,  -63,
+              -75,  -62,  -50]
+          }
+
+# Instantiate an example
+Example((input0, output0))
+
+# conv_quant8.mod.py with biases and filter being constants
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 3, 1}, 0.5f, -128")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 0.5f, -128",
+               [-126, -126, -126, -126])
+b1 = Parameter("op3", "TENSOR_INT32", "{1}, 0.25f, 0", [4])
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+# output dimension:
+#     (i1.height - f1.height + 1) x (i1.width - f1.width + 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 1.f, -128")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad0, pad0, pad0, pad0, stride,
+                        stride, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {
+    i1:  # input 0
+        [-120, -120, -120, -120, -124, -120, -120, -120, -120]
+}
+# (i1 (conv) f1) + b1
+output0 = {
+    output:  # output 0
+        [-113, -113, -113, -113]
+}
+
+# Instantiate an example
+Example((input0, output0))
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 3, 3}, 0.5, -128")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{3, 1, 1, 3}, 0.5, -128",
+               [-118, -88, -58, -108, -78, -48, -98, -68, -38])
+b1 = Parameter("op3", "TENSOR_INT32", "{3}, 0.25, 0", [0, 0, 0])
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+output = Output("op4",  "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 3, 3}, 1.0, -128")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad0, pad0, pad0, pad0, stride, stride, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [  -127,   -126,   -125,   -124,   -123,   -122,   -121,   -120,   -119,
+            -118,  -117,  -116,  -115,  -114,  -113,  -112,  -111,  -110]}
+
+output0 = {output: # output 0
+           [  -53,  -38,  -23,
+              37, 75, 112,
+              127, 127, 127,
+              127, 127, 127,
+              127, 127, 127,
+              127, 127, 127]
+          }
+
+# Instantiate an example
+Example((input0, output0))
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 3, 1}, 0.5f, -128")
+f1 = Input("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 0.5f, -128")
+b1 = Input("op3", "TENSOR_INT32", "{1}, 0.25f, 0")
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+# output dimension:
+#     (i1.height - f1.height + 1) x (i1.width - f1.width + 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 1}, 1.f, -128")
+
+model = model.Operation("CONV_2D", i1, f1, b1, pad0, pad0, pad0, pad0, stride, stride, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-120, -120, -120, -120, -124, -120, -120, -120, -120],
+          f1:
+          [-126, -126, -126, -126],
+          b1:
+          [4]}
+# (i1 (conv) f1) + b1
+output0 = {output: # output 0
+           [-113, -113, -113, -113]}
+
+# Instantiate an example
+Example((input0, output0))

--- a/test/cts/tool/CTSConverter/src/nn/specs/V1_3/depthwise_conv2d_quant8_signed.mod.py
+++ b/test/cts/tool/CTSConverter/src/nn/specs/V1_3/depthwise_conv2d_quant8_signed.mod.py
@@ -1,0 +1,526 @@
+#
+# Copyright (C) 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+layout = BoolScalar("layout", False) # NHWC
+
+# dilation set to 1 (default)
+i1 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 3, 2}")
+f1 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 4}", [.25, 0., .2, 0., .25, 0., 0., .3, .25, 0., 0., 0., .25, .1, 0., 0.])
+b1 = Parameter("op3", "TENSOR_FLOAT32", "{4}", [1, 2, 3, 4])
+o1 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 4}")
+Model().Operation("DEPTHWISE_CONV_2D", i1, f1, b1, 0, 0, 0, 0, 1, 1, 2, 0, layout, 1, 1).To(o1)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.01, -128),
+    b1: ("TENSOR_INT32", 0.005, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i1: [10, 21, 10, 22, 10, 23,
+         10, 24, 10, 25, 10, 26,
+         10, 27, 10, 28, 10, 29],
+    o1: [11, 3, 7.2, 10.6,
+         11, 3, 7.4, 10.9,
+         11, 3, 7.8, 11.5,
+         11, 3, 8.0, 11.8]
+}).AddNchw(i1, o1, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# dilation set to 2
+i2 = Input("op1", "TENSOR_FLOAT32", "{1, 4, 4, 2}")
+f2 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 4}", [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16])
+b2 = Parameter("op3", "TENSOR_FLOAT32", "{4}", [0,0,0,0])
+o2 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 4}")
+Model().Operation("DEPTHWISE_CONV_2D", i2, f2, b2, 0, 0, 0, 0, 1, 1, 2, 0, layout, 2, 2).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b2: ("TENSOR_INT32", 0.0625, 0),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 1, 1, 0, 0, 0,
+         0, 0, 0, 1, 1, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0,],
+    o2: [13, 14, 0, 0,
+         0, 0, 11, 12,
+         5, 6, 0, 0,
+         0, 0, 3, 4]
+}).AddNchw(i2, o2, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# same as test 1 but with implicit padding
+i1 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 3, 2}")
+f1 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 4}", [.25, 0., .2, 0., .25, 0., 0., .3, .25, 0., 0., 0., .25, .1, 0., 0.])
+b1 = Parameter("op3", "TENSOR_FLOAT32", "{4}", [1, 2, 3, 4])
+o1 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 4}")
+Model().Operation("DEPTHWISE_CONV_2D", i1, f1, b1, 2, 1, 1, 2, 0, layout, 1, 1).To(o1)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.01, -128),
+    b1: ("TENSOR_INT32", 0.005, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i1: [10, 21, 10, 22, 10, 23,
+         10, 24, 10, 25, 10, 26,
+         10, 27, 10, 28, 10, 29],
+    o1: [11, 3, 7.2, 10.6,
+         11, 3, 7.4, 10.9,
+         11, 3, 7.8, 11.5,
+         11, 3, 8.0, 11.8]
+}, name="valid_padding").AddNchw(i1, o1, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# same as test 2 but with implicit padding
+i2 = Input("op1", "TENSOR_FLOAT32", "{1, 4, 4, 2}")
+f2 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 4}", [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16])
+b2 = Parameter("op3", "TENSOR_FLOAT32", "{4}", [0,0,0,0])
+o2 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 4}")
+Model().Operation("DEPTHWISE_CONV_2D", i2, f2, b2, 2, 1, 1, 2, 0, layout, 2, 2).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, -128),
+    b2: ("TENSOR_INT32", 0.05, 0),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [0, 0, 0, 0, 0, 0, 0, 0,
+         0, 0, 0, 1, 1, 0, 0, 0,
+         0, 0, 0, 1, 1, 0, 0, 0,
+         0, 0, 0, 0, 0, 0, 0, 0,],
+    o2: [13, 14, 0, 0,
+         0, 0, 11, 12,
+         5, 6, 0, 0,
+         0, 0, 3, 4]
+}, name="valid_padding").AddNchw(i2, o2, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# dilation set to 3, padding SAME, stride 2
+i2 = Input("op1", "TENSOR_FLOAT32", "{1, 6, 6, 1}")
+f2 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 1}", [1, 2, 3, 4])
+b2 = Parameter("op3", "TENSOR_FLOAT32", "{1}", [0])
+o2 = Output("op4", "TENSOR_FLOAT32", "{1, 3, 3, 1}")
+Model().Operation("DEPTHWISE_CONV_2D", i2, f2, b2, 1, 2, 2, 1, 0, layout, 3, 3).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128),
+    b2: ("TENSOR_INT32", 0.0625, 0),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0,
+         0, 0, 1, 1, 0, 0,
+         0, 0, 1, 1, 0, 0,
+         0, 0, 0, 0, 0, 0,
+         0, 0, 0, 0, 0, 0],
+    o2: [4, 0, 3,
+         0, 0, 0,
+         2, 0, 1]
+}, name="same_padding_stride_2").AddNchw(i2, o2, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# Same scales, zeroPoint = 0
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128")
+f1 = Parameter("op2", "TENSOR_QUANT8_SYMM_PER_CHANNEL", "{1, 2, 2, 2}",
+               [2, 4,  2, 0,  2, 2,  2, 0],
+               extraParams = SymmPerChannelQuantParams(channelDim=3, scales=[0.5, 0.5]))
+b1 = Parameter("op3", "TENSOR_INT32", "{2}", [0, 0])
+o1 = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 2}, 1.f, -128")
+Model("same").Operation("DEPTHWISE_CONV_2D", i1, f1, b1, 0, 0, 0, 0, 1, 1, 1, 0).To(o1)
+
+# Instantiate an example
+Example({
+    i1: [-124, -112, -124, -96, -124, -64, -124, 0],
+    o1: [-120, -80],
+})
+
+#######################################################
+
+# Different scales, zeroPoint=128
+i2 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 3, 2}, 0.5f, 0")
+f2 = Parameter("op2", "TENSOR_QUANT8_SYMM_PER_CHANNEL", "{1, 2, 2, 4}",
+               [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+               extraParams = SymmPerChannelQuantParams(channelDim=3, scales=[1.0, 0.5, 1.0, 0.5]))
+b2 = Parameter("op3", "TENSOR_INT32", "{4}", [4, 4, 4, 4])
+o2 = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 4}, 1.f, 0")
+Model("different").Operation("DEPTHWISE_CONV_2D", i2, f2, b2, 0, 0, 0, 0, 1, 1, 2, 0).To(o2)
+
+# Instantiate an example
+Example({
+    i2: [1, 2] * 9,
+    o2: [4, 2, 6, 3, 4, 2, 6, 3,
+         4, 2, 6, 3, 4, 2, 6, 3],
+})
+
+#######################################################
+
+layout = BoolScalar("layout", False) # NHWC
+
+# With layout param
+i3 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 3, 2}, 0.5f, 0")
+f3 = Parameter("op2", "TENSOR_QUANT8_SYMM_PER_CHANNEL", "{1, 2, 2, 4}",
+               [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+               extraParams = SymmPerChannelQuantParams(channelDim=3, scales=[1.0, 0.5, 1.0, 0.5]))
+b3 = Parameter("op3", "TENSOR_INT32", "{4}", [4, 4, 4, 4])
+o3 = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 4}, 1.f, 0")
+Model("layout").Operation("DEPTHWISE_CONV_2D", i3, f3, b3, 0, 0, 0, 0, 1, 1, 2, 0, layout).To(o3)
+
+# Instantiate an example
+Example({
+    i3: [1, 2] * 9,
+    o3: [4, 2, 6, 3, 4, 2, 6, 3,
+         4, 2, 6, 3, 4, 2, 6, 3],
+}).AddNchw(i3, o3, layout)
+
+#######################################################
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 3, 2, 2}, 0.5f, -1")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 4}, 0.5f, -1", [1, 3, 5, 7, -19, 19, -23, 23, 9, 11, 13, 15, 25, -29, 29, -33])
+b1 = Parameter("op3", "TENSOR_INT32", "{4}, 0.25f, 0", [4, 8, 12, 16])
+pad_valid = Int32Scalar("pad_valid", 2)
+act_none = Int32Scalar("act_none", 0)
+stride = Int32Scalar("stride", 1)
+cm = Int32Scalar("channelMultiplier", 2)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 1, 4}, 1.f, -1")
+
+model = model.Operation("DEPTHWISE_CONV_2D",
+                        i1, f1, b1,
+                        pad_valid,
+                        stride, stride,
+                        cm, act_none).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [1, 3, 13, 15,
+           5, 7, 17, 19,
+           9, 11, 21, 23]}
+# (i1 (depthconv) f1)
+output0 = {output: # output 0
+           [70, -35, 98, -21,
+            90, -27, 126, -5]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128",
+               [-126, -124, -126, -128, -126, -126, -126, -128])
+b1 = Parameter("op3", "TENSOR_INT32", "{2}, 0.25f, 0", [0, 0])
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+cm = Int32Scalar("channelMultiplier", 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 2}, 1.f, -128")
+
+model = model.Operation("DEPTHWISE_CONV_2D",
+                        i1, f1, b1,
+                        pad0, pad0, pad0, pad0,
+                        stride, stride,
+                        cm, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-124, -112, -124, -96, -124, -64, -124, 0]}
+# (i1 (depthconv) f1)
+output0 = {output: # output 0
+           [-120, -80]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128")
+f1 = Input("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128")
+b1 = Input("op3", "TENSOR_INT32", "{2}, 0.25f, 0")
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+cm = Int32Scalar("channelMultiplier", 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 1, 1, 2}, 1.f, -128")
+
+model = model.Operation("DEPTHWISE_CONV_2D",
+                        i1, f1, b1,
+                        pad0, pad0, pad0, pad0,
+                        stride, stride,
+                        cm, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-124, -112, -124, -96, -124, -64, -124, 0],
+          f1:
+          [-126, -124,  -126, -128,  -126, -126,  -126, -128],
+          b1:
+          [0, 0]}
+# (i1 (depthconv) f1)
+output0 = {output: # output 0
+           [-120, -80]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128")
+f1 = Parameter("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128",
+               [-126, -124, -126, -128, -126, -126, -126, -128])
+b1 = Parameter("op3", "TENSOR_INT32", "{2}, 0.25f, 0", [0, 0])
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+cm = Int32Scalar("channelMultiplier", 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1,1,1,2}, 1.f, -128")
+
+model = model.Operation("DEPTHWISE_CONV_2D",
+                        i1, f1, b1,
+                        pad0, pad0, pad0, pad0,
+                        stride, stride,
+                        cm, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-124, -112, -124, -96, -124, -64, -124, 0]}
+# (i1 (depthconv) f1)
+output0 = {output: # output 0
+           [-120, -80]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+i1 = Input("op1", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128")
+f1 = Input("op2", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 2, 2, 2}, 0.5f, -128")
+b1 = Input("op3", "TENSOR_INT32", "{2}, 0.25f, 0")
+pad0 = Int32Scalar("pad0", 0)
+act = Int32Scalar("act", 0)
+stride = Int32Scalar("stride", 1)
+cm = Int32Scalar("channelMultiplier", 1)
+output = Output("op4", "TENSOR_QUANT8_ASYMM_SIGNED", "{1,1,1,2}, 1.f, -128")
+
+model = model.Operation("DEPTHWISE_CONV_2D",
+                        i1, f1, b1,
+                        pad0, pad0, pad0, pad0,
+                        stride, stride,
+                        cm, act).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: # input 0
+          [-124, -112, -124, -96, -124, -64, -124, 0],
+          f1:
+          [-126, -124,  -126, -128,  -126, -126,  -126, -128],
+          b1:
+          [0, 0]}
+# (i1 (depthconv) f1)
+output0 = {output: # output 0
+           [-120, -80]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+layout = BoolScalar("layout", False) # NHWC
+
+# DEPTHWISE_CONV2D_NCHW, pad = 0, stride = 1, cm = 2, act = none
+i1 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 3, 2}")
+f1 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 4}", [.25, 0., .2, 0., .25, 0., 0., .3, .25, 0., 0., 0., .25, .1, 0., 0.])
+b1 = Parameter("op3", "TENSOR_FLOAT32", "{4}", [1, 2, 3, 4])
+o1 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 2, 4}")
+Model().Operation("DEPTHWISE_CONV_2D", i1, f1, b1, 0, 0, 0, 0, 1, 1, 2, 0, layout).To(o1)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.01, -128),
+    b1: ("TENSOR_INT32", 0.005, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, -128)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=3, scales=[0.01, 0.005, 0.01, 0.005])),
+    b1: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.005, 0.0025, 0.005, 0.0025], hide=True)),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, -128)
+})
+channelQuant8_mult_gt_1 = DataTypeConverter().Identify({
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -128),
+    f1: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=3, scales=[0.01, 0.005, 0.01, 0.005])),
+    b1: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.005, 0.0025, 0.005, 0.0025], hide=True)),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.0001, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i1: [10, 21, 10, 22, 10, 23,
+         10, 24, 10, 25, 10, 26,
+         10, 27, 10, 28, 10, 29],
+    o1: [11, 3, 7.2, 10.6,
+         11, 3, 7.4, 10.9,
+         11, 3, 7.8, 11.5,
+         11, 3, 8.0, 11.8]
+}).AddNchw(i1, o1, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# DEPTHWISE_CONV2D_NCHW_2, pad = valid, stride = 1, cm = 2, act = none
+i2 = Input("op1", "TENSOR_FLOAT32", "{1, 3, 2, 2}")
+f2 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 4}", [1, 2, 3, 4, -9, 10, -11, 12, 5, 6, 7, 8, 13, -14, 15, -16])
+b2 = Parameter("op3", "TENSOR_FLOAT32", "{4}", [1, 2, 3, 4])
+o2 = Output("op4", "TENSOR_FLOAT32", "{1, 2, 1, 4}")
+Model().Operation("DEPTHWISE_CONV_2D", i2, f2, b2, 2, 1, 1, 2, 0, layout).To(o2)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    f2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    b2: ("TENSOR_INT32", 0.25, 0),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 1.0, -28)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i2: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    f2: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=3, scales=[0.5, 0.25, 0.5, 0.25])),
+    b2: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.25, 0.125, 0.25, 0.125], hide=True)),
+    o2: ("TENSOR_QUANT8_ASYMM_SIGNED", 1.0, -28)
+})
+
+# Instantiate an example
+example = Example({
+    i2: [1, 2, 7, 8, 3, 4, 9, 10, 5, 6, 11, 12],
+    o2: [71, -34, 99, -20, 91, -26, 127, -4]
+}).AddNchw(i2, o2, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# DEPTHWISE_CONV2D_NCHW_LARGE, pad = 0, stride = 1, cm = 1, act = none
+i3 = Input("op1", "TENSOR_FLOAT32", "{1, 2, 2, 2}")
+f3 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 2}", [.25, 0, .25, 1, .25, 0, .25, 1])
+b3 = Parameter("op3", "TENSOR_FLOAT32", "{2}", [100, 200])
+o3 = Output("op4", "TENSOR_FLOAT32", "{1, 1, 1, 2}")
+Model("large").Operation("DEPTHWISE_CONV_2D", i3, f3, b3, 0, 0, 0, 0, 1, 1, 1, 0, layout).To(o3)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, -28),
+    f3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.125, 0),
+    b3: ("TENSOR_INT32", 0.0625, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 2.0, 0)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i3: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    f3: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=3, scales=[0.125, 0.25])),
+    b3: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.0625, 0.125], hide=True)),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 2.0, 0)
+})
+
+# Instantiate an example
+example = Example({
+    i3: [10, 21, 10, 22, 10, 23, 10, 24],
+    o3: [110, 246]
+}).AddNchw(i3, o3, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# DEPTHWISE_CONV2D_NCHW_LARGE, pad = 0, stride = 1, cm = 1, act = none
+i4 = Input("op1", "TENSOR_FLOAT32", "{1, 2, 2, 4}")
+f4 = Parameter("op2", "TENSOR_FLOAT32", "{1, 2, 2, 4}", [.25, 0, 10, 50, .25, 1, 20, 50, .25, 0, 30, 50, .25, 1, 40, 50])
+b4 = Parameter("op3", "TENSOR_FLOAT32", "{4}", [6000, 7000, 8000, 9000])
+o4 = Output("op4", "TENSOR_FLOAT32", "{1, 1, 1, 4}")
+Model("large").Operation("DEPTHWISE_CONV_2D", i4, f4, b4, 0, 0, 0, 0, 1, 1, 1, 0, layout).To(o4)
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    f4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.25, -128),
+    b4: ("TENSOR_INT32", 0.125, 0),
+    o4: ("TENSOR_QUANT8_ASYMM_SIGNED", 50.0, -128)
+})
+channelquant8_signed = DataTypeConverter().Identify({
+    i4: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.5, 0),
+    f4: ("TENSOR_QUANT8_SYMM_PER_CHANNEL", 0, 0, SymmPerChannelQuantParams(channelDim=3, scales=[1.0, 2.0, 1.0, 1.0])),
+    b4: ("TENSOR_INT32", 0.0, 0, SymmPerChannelQuantParams(channelDim=0, scales=[0.5, 1.0, 0.5, 0.5], hide=True)),
+    o4: ("TENSOR_QUANT8_ASYMM_SIGNED", 50.0, -128)
+})
+
+# Instantiate an example
+example = Example({
+    i4: [10, 21, 10, 0,
+         10, 22, 20, 0,
+         10, 23, 30, 0,
+         10, 24, 40, 0],
+    o4: [6010, 7046, 11000, 9000]
+}).AddNchw(i4, o4, layout).AddVariations(quant8_signed, includeDefault=False)
+
+#######################################################
+
+# quantized with scale product greater than output scale
+input_scale = 256.5 / 255
+input_zero_point = -1
+filter_scale = 256.5 / 255
+filter_zero_point = 0
+i9 = Input("op1",
+           ("TENSOR_QUANT8_ASYMM_SIGNED", [1, 3, 2, 2], input_scale, input_zero_point))
+f9 = Parameter(
+    "op2",
+    ("TENSOR_QUANT8_ASYMM_SIGNED", [1, 2, 2, 4], filter_scale, filter_zero_point), [
+        1, 2, 3, 4, -9, 10, -11, 12, 5, 6, 7, 8, 13, -14,
+        15, -16
+    ])
+b9 = Parameter("op3", ("TENSOR_INT32", [4], input_scale * filter_scale, 0),
+               [2, 4, 6, 8])
+o9 = Output("op4", ("TENSOR_QUANT8_ASYMM_SIGNED", [1, 2, 1, 4], 1.0, -1))
+model9 = Model("quant_output_multiplier_gt_1").Operation("DEPTHWISE_CONV_2D", i9, f9, b9, 2, 1, 1, 2,
+                           0).To(o9)
+
+# Instantiate an example
+example = Example({
+    i9: [1, 3, 13, 15, 5, 7, 17, 19, 9, 11, 21, 23],
+    o9: [127, -70, 127, -41, 127, -54, 127, -9]
+}, model=model9)

--- a/test/cts/tool/CTSConverter/src/nn/specs/V1_3/softmax_quant8_signed.mod.py
+++ b/test/cts/tool/CTSConverter/src/nn/specs/V1_3/softmax_quant8_signed.mod.py
@@ -1,0 +1,136 @@
+#
+# Copyright (C) 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+model = Model()
+
+i1 = Input("input", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 4}, 0.5f, -128") # batch = 1, depth = 1
+beta = Float32Scalar("beta", 0.00001) # close to 0
+output = Output("output", "TENSOR_QUANT8_ASYMM_SIGNED", "{1, 4}, 0.00390625f, -128")
+
+# model 1
+model = model.Operation("SOFTMAX", i1, beta).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1: [-127, -126, -118, -108]}
+
+output0 = {output: [-64, -64, -64, -64]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+model = Model()
+
+i1 = Input("input", "TENSOR_QUANT8_ASYMM_SIGNED", "{2, 5}, 0.5f, -128") # batch = 2, depth = 5
+beta = Float32Scalar("beta", 1.)
+output = Output("output", "TENSOR_QUANT8_ASYMM_SIGNED", "{2, 5}, 0.00390625f, -128")
+
+# model 1
+model = model.Operation("SOFTMAX", i1, beta).To(output)
+
+# Example 1. Input in operand 0,
+input0 = {i1:
+          [-127, -126, -125, -124, -123,
+           127, 126, 125, 124, 123]}
+
+output0 = {output:
+           [-113, -104, -88, -61, -18,
+            -18, -61, -88, -104, -113]}
+
+# Instantiate an example
+Example((input0, output0))
+
+#######################################################
+
+i = Input("op1", "TENSOR_FLOAT32", "{2, 2, 2, 5}") # input 0
+o = Output("op2", "TENSOR_FLOAT32", "{2, 2, 2, 5}") # output 0
+axis = Int32Scalar("axis", -1) # last axis
+
+# Additional data type
+quant8_signed = DataTypeConverter().Identify({
+    i: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.25, 0),
+    o: ("TENSOR_QUANT8_ASYMM_SIGNED", 1./256, -128)
+})
+
+example1 = {
+    i: [17., 16., 15., 14.,  1.,
+        -1., -2., -3., -4., -17.] * 4,
+    o: [0.643914213228014,
+        0.236882800924671,
+        0.087144312427294,
+        0.032058600957022,
+        7.246299848982885e-08] * 8
+}
+example2 = {
+    i: [1., 2., 3., 4., 5., -1., -2., -3., -4., -5.] * 4,
+    o: [0.2] * 40
+}
+
+# All dimensions other than 2 or 4, without axis parameter
+# beta = 1.0
+Model().Operation("SOFTMAX", i, 1.0).To(o)
+Example(example1).AddVariations(quant8_signed, includeDefault=False).AddDims([1, 3], i, o)
+# beta = 0.000001
+Model().Operation("SOFTMAX", i, 0.000001).To(o)
+Example(example2).AddVariations(quant8_signed, includeDefault=False).AddDims([1, 3], i, o)
+
+#######################################################
+# All dimensions, with all possible axis parameter
+# beta = 1.0
+Model("axis").Operation("SOFTMAX", i, 1.0, axis).To(o)
+Example(example1).AddVariations(quant8_signed, includeDefault=False).AddAllDimsAndAxis(i, o, axis)
+# beta = 0.000001
+Model("axis").Operation("SOFTMAX", i, 0.000001, axis).To(o)
+Example(example2).AddVariations(quant8_signed, includeDefault=False).AddAllDimsAndAxis(i, o, axis)
+
+#######################################################
+# zero-sized input
+
+# Use BOX_WITH_NMS_LIMIT op to generate a zero-sized internal tensor for box cooridnates.
+p1 = Parameter("scores", "TENSOR_FLOAT32", "{1, 2}", [0.90, 0.10]) # scores
+p2 = Parameter("roi", "TENSOR_FLOAT32", "{1, 8}", [1, 1, 10, 10, 0, 0, 10, 10]) # roi
+o1 = Output("scoresOut", "TENSOR_FLOAT32", "{0}") # scores out
+o2 = Output("classesOut", "TENSOR_INT32", "{0}") # classes out
+tmp1 = Internal("roiOut", "TENSOR_FLOAT32", "{0, 4}") # roi out
+tmp2 = Internal("batchSplitOut", "TENSOR_INT32", "{0}") # batch split out
+model = Model("zero_sized").Operation("BOX_WITH_NMS_LIMIT", p1, p2, [0], 0.3,  -1, 0, 0.4, 1.0, 0.3).To(o1, tmp1, o2, tmp2)
+
+# Use ROI_ALIGN op to convert into zero-sized feature map.
+layout = BoolScalar("layout", False) # NHWC
+i1 = Input("in", "TENSOR_FLOAT32", "{1, 1, 1, 1}")
+zero_sized = Internal("featureMap", "TENSOR_FLOAT32", "{0, 2, 2, 1}")
+model = model.Operation("ROI_ALIGN", i1, tmp1, tmp2, 2, 2, 2.0, 2.0, 4, 4, layout).To(zero_sized)
+
+# SOFTMAX op with numBatches = 0.
+o3 = Output("out", "TENSOR_FLOAT32", "{0, 2, 2, 1}") # out
+model = model.Operation("SOFTMAX", zero_sized, 1.0).To(o3)
+
+quant8_signed = DataTypeConverter().Identify({
+    p1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    p2: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    o1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    tmp1: ("TENSOR_QUANT16_ASYMM", 0.125, 0),
+    i1: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    zero_sized: ("TENSOR_QUANT8_ASYMM_SIGNED", 0.1, 0),
+    o3: ("TENSOR_QUANT8_ASYMM_SIGNED", 1./256, -128)
+})
+
+Example({
+    i1: [1],
+    o1: [],
+    o2: [],
+    o3: [],
+}).AddVariations(quant8_signed, includeDefault=False)

--- a/test/cts/tool/CTSConverter/src/test_generator.py
+++ b/test/cts/tool/CTSConverter/src/test_generator.py
@@ -1396,6 +1396,7 @@ class Configuration:
         "LSTM",
         "MAX_POOL_2D",
         "MUL",
+        "QUANTIZE",
         "RELU",
         "RELU1",
         "RELU6",
@@ -1471,19 +1472,24 @@ class Configuration:
             "inputs": {
                 0: {
                     "layout": ["NHWC"],
-                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM"],
+                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM", "TENSOR_QUANT8_ASYMM_SIGNED"],
                     "dimensions": [2, 4]
                 },
                 1: {
                     "layout": ["NHWC"],
                     "types": ["FLOAT32"],
                     "dimensions": [0]
+                },
+                2: {
+                    "layout": ["NHWC"],
+                    "types": ["INT32"],
+                    "dimensions": [0]
                 }
             },
             "outputs": {
                 0: {
                     "layout": ["NHWC"],
-                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM"],
+                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM", "TENSOR_QUANT8_ASYMM_SIGNED"],
                     "dimensions": [2, 4]
                 }
             }
@@ -1671,7 +1677,7 @@ class Configuration:
             "inputs": {
                 0: {
                     "layout": ["NHWC"],
-                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM"],
+                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM", "TENSOR_QUANT8_ASYMM_SIGNED"],
                     "dimensions": [4]
                 },
                 1: {
@@ -1723,7 +1729,7 @@ class Configuration:
             "outputs": {
                 0: {
                     "layout": ["NHWC"],
-                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM"],
+                    "types": ["TENSOR_FLOAT32", "TENSOR_QUANT8_ASYMM", "TENSOR_QUANT8_ASYMM_SIGNED"],
                     "dimensions": [4]
                 }
             }


### PR DESCRIPTION
Update CTSConverter to support new ops with int8 datatype：

1. avg_pool
2. conv2d
3. depthwise_conv2d
4. softmax

Signed-off-by: cuiyanx <yanx.cui@intel.com>