### PR TITLE
[test] Updated three depthwise_conv2d tests using Relu activations align with updated V1_0/depthwise_conv2d_float_large_2_weights_as_inputs.js

### DIFF
--- a/test/cts/test/V1_0_plus/depthwise_conv2d_float_large_2_weights_as_inputs_relu.js
+++ b/test/cts/test/V1_0_plus/depthwise_conv2d_float_large_2_weights_as_inputs_relu.js
@@ -3,51 +3,47 @@ describe('CTS', function() {
   const nn = navigator.ml.getNeuralNetworkContext();
 
   it('check result for Depthwise conv2d float large 2 weights as inputs relu example', async function() {
+    // For 'Depthwise conv2d float large 2 weights as inputs' example: examples
     let model = await nn.createModel(options);
     let operandIndex = 0;
 
-    let op1_value = [10, 21, 100, 10, 22, 200, 10, 23, 300, 10, 24, 400];
+    let op1_value = [10, 21, 100, 0, 10, 22, 200, 0, 10, 23, 300, 0, 10, 24, 400, 0];
     let op2_value = [0.25, 0, 10, 100, 0.25, 1, 20, 100, 0.25, 0, 30, 100, 0.25, 1, 40, 100];
     let op3_value = [600000, 700000, 800000, 900000];
     let op4_expect = [600010, 700046, 830000, 900000];
 
-    let type3 = {type: nn.INT32};
-    let type4 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 1, 1, 4]};
-    let type4_length = product(type4.dimensions);
-    let type0 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 3]};
+    let type0 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 4]};
     let type0_length = product(type0.dimensions);
-    let type1 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 4]};
+    let type1 = {type: nn.TENSOR_FLOAT32, dimensions: [4]};
     let type1_length = product(type1.dimensions);
-    let type2 = {type: nn.TENSOR_FLOAT32, dimensions: [4]};
-    let type2_length = product(type2.dimensions);
+    let type2 = {type: nn.INT32};
+    let type3 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 1, 1, 4]};
+    let type3_length = product(type3.dimensions);
 
     let op1 = operandIndex++;
     model.addOperand(type0);
     let op2 = operandIndex++;
-    model.addOperand(type1);
+    model.addOperand(type0);
     let op3 = operandIndex++;
-    model.addOperand(type2);
+    model.addOperand(type1);
     let pad0 = operandIndex++;
-    model.addOperand(type3);
-    let act = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
     let stride = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
     let channelMultiplier = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
+    let act = operandIndex++;
+    model.addOperand(type2);
     let op4 = operandIndex++;
-    model.addOperand(type4);
+    model.addOperand(type3);
 
-    let op2_input = new Float32Array(op2_value);
-    model.setOperandValue(op2, op2_input);
-
-    let op3_input = new Float32Array(op3_value);
-    model.setOperandValue(op3, op3_input);
+    model.setOperandValue(op2, new Float32Array(op2_value));
+    model.setOperandValue(op3, new Float32Array(op3_value));
 
     model.setOperandValue(pad0, new Int32Array([0]));
-    model.setOperandValue(act, new Int32Array([1]));
     model.setOperandValue(stride, new Int32Array([1]));
     model.setOperandValue(channelMultiplier, new Int32Array([1]));
+    model.setOperandValue(act, new Int32Array([1]));
     model.addOperation(nn.DEPTHWISE_CONV_2D, [op1, op2, op3, pad0, pad0, pad0, pad0, stride, stride, channelMultiplier, act], [op4]);
 
     model.identifyInputsAndOutputs([op1], [op4]);
@@ -61,13 +57,12 @@ describe('CTS', function() {
 
     let op1_input = new Float32Array(op1_value);
     execution.setInput(0, op1_input);
-
-    let op4_output = new Float32Array(type4_length);
+    let op4_output = new Float32Array(type3_length);
     execution.setOutput(0, op4_output);
 
     await execution.startCompute();
 
-    for (let i = 0; i < type4_length; ++i) {
+    for (let i = 0; i < type3_length; ++i) {
       assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
     }
   });

--- a/test/cts/test/V1_0_plus/depthwise_conv2d_float_large_2_weights_as_inputs_relu1.js
+++ b/test/cts/test/V1_0_plus/depthwise_conv2d_float_large_2_weights_as_inputs_relu1.js
@@ -3,51 +3,47 @@ describe('CTS', function() {
   const nn = navigator.ml.getNeuralNetworkContext();
 
   it('check result for Depthwise conv2d float large 2 weights as inputs relu1 example', async function() {
+    // For 'Depthwise conv2d float large 2 weights as inputs' example: examples
     let model = await nn.createModel(options);
     let operandIndex = 0;
 
-    let op1_value = [10, 21, 100, 10, 22, 200, 10, 23, 300, 10, 24, 400];
+    let op1_value = [10, 21, 100, 0, 10, 22, 200, 0, 10, 23, 300, 0, 10, 24, 400, 0];
     let op2_value = [0.25, 0, 10, 100, 0.25, 1, 20, 100, 0.25, 0, 30, 100, 0.25, 1, 40, 100];
     let op3_value = [600000, 700000, 800000, 900000];
     let op4_expect = [1, 1, 1, 1];
 
-    let type3 = {type: nn.INT32};
-    let type4 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 1, 1, 4]};
-    let type4_length = product(type4.dimensions);
-    let type0 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 3]};
+    let type0 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 4]};
     let type0_length = product(type0.dimensions);
-    let type1 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 4]};
+    let type1 = {type: nn.TENSOR_FLOAT32, dimensions: [4]};
     let type1_length = product(type1.dimensions);
-    let type2 = {type: nn.TENSOR_FLOAT32, dimensions: [4]};
-    let type2_length = product(type2.dimensions);
+    let type2 = {type: nn.INT32};
+    let type3 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 1, 1, 4]};
+    let type3_length = product(type3.dimensions);
 
     let op1 = operandIndex++;
     model.addOperand(type0);
     let op2 = operandIndex++;
-    model.addOperand(type1);
+    model.addOperand(type0);
     let op3 = operandIndex++;
-    model.addOperand(type2);
+    model.addOperand(type1);
     let pad0 = operandIndex++;
-    model.addOperand(type3);
-    let act = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
     let stride = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
     let channelMultiplier = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
+    let act = operandIndex++;
+    model.addOperand(type2);
     let op4 = operandIndex++;
-    model.addOperand(type4);
+    model.addOperand(type3);
 
-    let op2_input = new Float32Array(op2_value);
-    model.setOperandValue(op2, op2_input);
-
-    let op3_input = new Float32Array(op3_value);
-    model.setOperandValue(op3, op3_input);
+    model.setOperandValue(op2, new Float32Array(op2_value));
+    model.setOperandValue(op3, new Float32Array(op3_value));
 
     model.setOperandValue(pad0, new Int32Array([0]));
-    model.setOperandValue(act, new Int32Array([2]));
     model.setOperandValue(stride, new Int32Array([1]));
     model.setOperandValue(channelMultiplier, new Int32Array([1]));
+    model.setOperandValue(act, new Int32Array([2]));
     model.addOperation(nn.DEPTHWISE_CONV_2D, [op1, op2, op3, pad0, pad0, pad0, pad0, stride, stride, channelMultiplier, act], [op4]);
 
     model.identifyInputsAndOutputs([op1], [op4]);
@@ -61,13 +57,12 @@ describe('CTS', function() {
 
     let op1_input = new Float32Array(op1_value);
     execution.setInput(0, op1_input);
-
-    let op4_output = new Float32Array(type4_length);
+    let op4_output = new Float32Array(type3_length);
     execution.setOutput(0, op4_output);
 
     await execution.startCompute();
 
-    for (let i = 0; i < type4_length; ++i) {
+    for (let i = 0; i < type3_length; ++i) {
       assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
     }
   });

--- a/test/cts/test/V1_0_plus/depthwise_conv2d_float_large_2_weights_as_inputs_relu6.js
+++ b/test/cts/test/V1_0_plus/depthwise_conv2d_float_large_2_weights_as_inputs_relu6.js
@@ -3,51 +3,47 @@ describe('CTS', function() {
   const nn = navigator.ml.getNeuralNetworkContext();
 
   it('check result for Depthwise conv2d float large 2 weights as inputs relu6 example', async function() {
+    // For 'Depthwise conv2d float large 2 weights as inputs' example: examples
     let model = await nn.createModel(options);
     let operandIndex = 0;
 
-    let op1_value = [10, 21, 100, 10, 22, 200, 10, 23, 300, 10, 24, 400];
+    let op1_value = [10, 21, 100, 0, 10, 22, 200, 0, 10, 23, 300, 0, 10, 24, 400, 0];
     let op2_value = [0.25, 0, 10, 100, 0.25, 1, 20, 100, 0.25, 0, 30, 100, 0.25, 1, 40, 100];
     let op3_value = [600000, 700000, 800000, 900000];
     let op4_expect = [6, 6, 6, 6];
 
-    let type3 = {type: nn.INT32};
-    let type4 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 1, 1, 4]};
-    let type4_length = product(type4.dimensions);
-    let type0 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 3]};
+    let type0 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 4]};
     let type0_length = product(type0.dimensions);
-    let type1 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 2, 2, 4]};
+    let type1 = {type: nn.TENSOR_FLOAT32, dimensions: [4]};
     let type1_length = product(type1.dimensions);
-    let type2 = {type: nn.TENSOR_FLOAT32, dimensions: [4]};
-    let type2_length = product(type2.dimensions);
+    let type2 = {type: nn.INT32};
+    let type3 = {type: nn.TENSOR_FLOAT32, dimensions: [1, 1, 1, 4]};
+    let type3_length = product(type3.dimensions);
 
     let op1 = operandIndex++;
     model.addOperand(type0);
     let op2 = operandIndex++;
-    model.addOperand(type1);
+    model.addOperand(type0);
     let op3 = operandIndex++;
-    model.addOperand(type2);
+    model.addOperand(type1);
     let pad0 = operandIndex++;
-    model.addOperand(type3);
-    let act = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
     let stride = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
     let channelMultiplier = operandIndex++;
-    model.addOperand(type3);
+    model.addOperand(type2);
+    let act = operandIndex++;
+    model.addOperand(type2);
     let op4 = operandIndex++;
-    model.addOperand(type4);
+    model.addOperand(type3);
 
-    let op2_input = new Float32Array(op2_value);
-    model.setOperandValue(op2, op2_input);
-
-    let op3_input = new Float32Array(op3_value);
-    model.setOperandValue(op3, op3_input);
+    model.setOperandValue(op2, new Float32Array(op2_value));
+    model.setOperandValue(op3, new Float32Array(op3_value));
 
     model.setOperandValue(pad0, new Int32Array([0]));
-    model.setOperandValue(act, new Int32Array([3]));
     model.setOperandValue(stride, new Int32Array([1]));
     model.setOperandValue(channelMultiplier, new Int32Array([1]));
+    model.setOperandValue(act, new Int32Array([3]));
     model.addOperation(nn.DEPTHWISE_CONV_2D, [op1, op2, op3, pad0, pad0, pad0, pad0, stride, stride, channelMultiplier, act], [op4]);
 
     model.identifyInputsAndOutputs([op1], [op4]);
@@ -61,13 +57,12 @@ describe('CTS', function() {
 
     let op1_input = new Float32Array(op1_value);
     execution.setInput(0, op1_input);
-
-    let op4_output = new Float32Array(type4_length);
+    let op4_output = new Float32Array(type3_length);
     execution.setOutput(0, op4_output);
 
     await execution.startCompute();
 
-    for (let i = 0; i < type4_length; ++i) {
+    for (let i = 0; i < type3_length; ++i) {
       assert.isTrue(almostEqualCTS(op4_output[i], op4_expect[i]));
     }
   });


### PR DESCRIPTION
Update these three CTS tests using Relu activations align with updated [V1_0/depthwise_conv2d_float_large_2_weights_as_inputs.js](https://github.com/intel/webml-polyfill/blob/master/test/cts/test/V1_0/depthwise_conv2d_float_large_2_weights_as_inputs.js).

@mingmingtasd @ibelem PTAL, thanks.