### PR TITLE
[tools] Update CI baseline data for new Wasm backend

### DIFF
--- a/test/tools/CI/baseline/baseline.config.json
+++ b/test/tools/CI/baseline/baseline.config.json
@@ -1,30 +1,30 @@
 {
     "Version": {
         "chromium": "ef9d267",
-        "polyfill": "853173e"
+        "polyfill": "04af842"
     },
     "Android-Polyfill-Fast-WASM": {
         "total": 178,
-        "pass": 178,
-        "fail": 0,
+        "pass": 177,
+        "fail": 1,
         "block": 0
     },   
     "Linux-Polyfill-Fast-WASM": {
         "total": 178,
-        "pass": 178,
-        "fail": 0,
+        "pass": 177,
+        "fail": 1,
         "block": 0
     }, 
     "macOS-Polyfill-Fast-WASM": {
         "total": 178,
-        "pass": 178,
-        "fail": 0,
+        "pass": 177,
+        "fail": 1,
         "block": 0
     },
     "Win-Polyfill-Fast-WASM": {
         "total": 178,
-        "pass": 178,
-        "fail": 0,
+        "pass": 177,
+        "fail": 1,
         "block": 0
     }
     

--- a/test/tools/CI/baseline/unitTestsBaseline.csv
+++ b/test/tools/CI/baseline/unitTestsBaseline.csv
@@ -121,7 +121,7 @@ CTS,CTS/117,check result for Max pool float example/2,Pass,Pass,Pass,Pass
 CTS,CTS/118,check result for Max pool float example/3,Pass,Pass,Pass,Pass
 CTS,CTS/119,check result for MAXIMUM example,Pass,Pass,Pass,Pass
 CTS,CTS/120,check result for MAXIMUM as 4-D tensor example,Pass,Pass,Pass,Pass
-CTS,CTS/121,check result for MAXIMUM as compatible dimensions example,Pass,Pass,Pass,Pass
+CTS,CTS/121,check result for MAXIMUM as compatible dimensions example,Fail,Fail,Fail,Fail
 CTS,CTS/122,check result for Mul example,Pass,Pass,Pass,Pass
 CTS,CTS/123,check result for Mul relu example,Pass,Pass,Pass,Pass
 CTS,CTS/124,check result for Mul relu1 example,Pass,Pass,Pass,Pass


### PR DESCRIPTION
One MAXIMUM test case failed with TF.js Wasm backend(#1253), so update CI baseline data for this.