### PR TITLE
[test] Enabled test by WebGPU backend using prefer=sustained&webgpu=true parameters.

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -109,75 +109,71 @@ function setOptionsPerLayer() {
 
 function setOptions() {
   // visit URL(http://domain-name/test/index.html?prefer=fast/sustained/low)
-  var parameterStr = window.location.search.substr(1);
-  var reg = new RegExp("(^|&)prefer=([^&]*)(&|$)", "i");
-  // use webgpu=true parameter for WebGPU backend
-  var webgpu_reg = new RegExp("(^|&)webgpu=([^&]*)(&|$)", "i");
-  var r = parameterStr.match(reg);
-  var webgpu_r = parameterStr.match(webgpu_reg);
-  var macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
-  var windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
-  if (r != null) {
-    var prefer = unescape(r[2]).toLowerCase();
-    if (navigator.ml.isPolyfill) {
-      if (prefer === "fast") {
+  const parameterStr = new URLSearchParams(location.search);
+  const prefer = parameterStr.get('prefer');
+
+  const macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
+  const windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
+
+  if (navigator.ml.isPolyfill) {
+    if (prefer === "fast") {
+      options = {
+        "backend": 'WASM',
+        "prefer": 'fast',
+        'iterations': "1"
+      };
+    } else if (prefer === "sustained") {
+      const webgpu = parameterStr.get('webgpu');
+      if (webgpu !== null && webgpu === 'true') {
         options = {
-          "backend": 'WASM',
-          "prefer": 'fast',
-          'iterations': "1"
-        };
-      } else if (prefer === "sustained") {
-        if (webgpu_r != null && Boolean(unescape(webgpu_r[2]).toLowerCase())) {
-          options = {
-            "backend": 'WebGPU',
-            "prefer": 'sustained',
-            'iterations': "1"
-          };
-        } else {
-          options = {
-            "backend": 'WebGL',
-            "prefer": 'sustained',
-            'iterations': "1"
-          };
-        }
-      }
-    } else {
-      if (prefer === "sustained") {
-        // use PREFER_SUSTAINED_SPEED for Linux/Windows clDNN backend
-        prefer = nn.PREFER_SUSTAINED_SPEED;
-        options = {
-          "backend": 'WebML',
+          "backend": 'WebGPU',
           "prefer": 'sustained',
           'iterations': "1"
         };
-        // As MPS computes on FP16, use 5ULP of FP16 range
-        if (macosPlatforms.indexOf(navigator.platform) !== -1 || windowsPlatforms.indexOf(navigator.platform) !== -1) {
-          episilonCTS = EPISILON5ULP;
-          rtol = EPISILON5ULP;
-        }
-      } else if (prefer === "fast") {
-        // use PREFER_FAST_SINGLE_ANSWER for Linux/Windows mkldnn backend
-        prefer = nn.PREFER_FAST_SINGLE_ANSWER;
+      } else {
         options = {
-          "backend": 'WebML',
-          "prefer": 'fast',
-          'iterations': "1"
-        };
-      } else if (prefer === "low") {
-        prefer = nn.PREFER_LOW_POWER;
-        options = {
-          "backend": 'WebML',
-          "prefer": 'low',
-          'iterations': "1"
-        };
-      } else if (prefer === "ultra-low") {
-        prefer = nn.PREFER_ULTRA_LOW_POWER;
-        options = {
-          "backend": 'WebML',
-          "prefer": 'ultra-low',
+          "backend": 'WebGL',
+          "prefer": 'sustained',
           'iterations': "1"
         };
       }
+    }
+  } else {
+    if (prefer === "sustained") {
+      // use PREFER_SUSTAINED_SPEED for Linux/Windows clDNN backend
+      prefer = nn.PREFER_SUSTAINED_SPEED;
+      options = {
+        "backend": 'WebML',
+        "prefer": 'sustained',
+        'iterations': "1"
+      };
+      // As MPS computes on FP16, use 5ULP of FP16 range
+      if (macosPlatforms.indexOf(navigator.platform) !== -1 || windowsPlatforms.indexOf(navigator.platform) !== -1) {
+        episilonCTS = EPISILON5ULP;
+        rtol = EPISILON5ULP;
+      }
+    } else if (prefer === "fast") {
+      // use PREFER_FAST_SINGLE_ANSWER for Linux/Windows mkldnn backend
+      prefer = nn.PREFER_FAST_SINGLE_ANSWER;
+      options = {
+        "backend": 'WebML',
+        "prefer": 'fast',
+        'iterations': "1"
+      };
+    } else if (prefer === "low") {
+      prefer = nn.PREFER_LOW_POWER;
+      options = {
+        "backend": 'WebML',
+        "prefer": 'low',
+        'iterations': "1"
+      };
+    } else if (prefer === "ultra-low") {
+      prefer = nn.PREFER_ULTRA_LOW_POWER;
+      options = {
+        "backend": 'WebML',
+        "prefer": 'ultra-low',
+        'iterations': "1"
+      };
     }
   }
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -111,7 +111,10 @@ function setOptions() {
   // visit URL(http://domain-name/test/index.html?prefer=fast/sustained/low)
   var parameterStr = window.location.search.substr(1);
   var reg = new RegExp("(^|&)prefer=([^&]*)(&|$)", "i");
+  // use webgpu=true parameter for WebGPU backend
+  var webgpu_reg = new RegExp("(^|&)webgpu=([^&]*)(&|$)", "i");
   var r = parameterStr.match(reg);
+  var webgpu_r = parameterStr.match(webgpu_reg);
   var macosPlatforms = ['Macintosh', 'MacIntel', 'MacPPC', 'Mac68K'];
   var windowsPlatforms = ['Win32', 'Win64', 'Windows', 'WinCE'];
   if (r != null) {
@@ -124,11 +127,19 @@ function setOptions() {
           'iterations': "1"
         };
       } else if (prefer === "sustained") {
-        options = {
-          "backend": 'WebGL',
-          "prefer": 'sustained',
-          'iterations': "1"
-        };
+        if (webgpu_r != null && Boolean(unescape(webgpu_r[2]).toLowerCase())) {
+          options = {
+            "backend": 'WebGPU',
+            "prefer": 'sustained',
+            'iterations': "1"
+          };
+        } else {
+          options = {
+            "backend": 'WebGL',
+            "prefer": 'sustained',
+            'iterations': "1"
+          };
+        }
       }
     } else {
       if (prefer === "sustained") {


### PR DESCRIPTION
For PR #1203,  use prefer=sustained&webgpu=true parameters to enable test by WebGPU backend on Windows and macOS platforms, since 'Unsafe WebGPU' flag only works on Windows and macOS platforms. 

@huningxin @ibelem @NALLEIN  PTAL, thanks