### PR TITLE
[demo] Fix issue of using video element as default input for Image Classification demo with video.

### DIFF
--- a/examples/image_classification_opencv/ImageClassificationExample.js
+++ b/examples/image_classification_opencv/ImageClassificationExample.js
@@ -35,7 +35,7 @@ class ImageClassificationExample extends BaseExample {
         this._setOpenCVJSBackend('WASM');
         this._setModelId('none');
         this._setInputType('camera');
-        this._setInputElement(this._feedElement);
+        this._setInputElement(this._feedMediaElement);
         this._setHiddenControlsFlag('0');
         this._setFramework('OpenCV.js');
         this._setRuntimeInitialized(false);


### PR DESCRIPTION
@ibelem I tested [online examples](https://intel.github.io/webml-polyfill/examples/image_classification_opencv/) and found the inference result (not tiger cat, still less panda) issue , this PR would fix it, PTAL, thanks 