### PR TITLE
[polyfill] Supported WebGPU backend.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "typescript": "^3.9.5",
     "webpack": "^4.26.0",
     "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.10"
+    "webpack-dev-server": "^3.1.10",
+    "@webgpu/glslang": "0.0.12",
+    "@webgpu/types": "0.0.24",
+    "@tensorflow/tfjs-backend-webgpu": "0.0.1-alpha.4"
   }
 }

--- a/src/nn/Compilation.js
+++ b/src/nn/Compilation.js
@@ -7,7 +7,7 @@ import TfjsModel from './tfjs/TfjsModel'
 export default class Compilation {
   /**
    * Create a Compilation to compile the given model.
-   * 
+   *
    * @param {Model} model - The model to be compiled.
    */
   constructor(model) {
@@ -22,7 +22,7 @@ export default class Compilation {
 
   /**
    * Create a executino from compilation.
-   * 
+   *
    * @returns {Execution} - the execution object.
    */
   async createExecution() {
@@ -34,7 +34,7 @@ export default class Compilation {
 
   /**
    * Sets the execution preference.
-   * 
+   *
    * @param {number} preference - The execution preference, e.g. PreferenceCode.LOW_POWER.
    */
   setPreference(preference) {
@@ -59,11 +59,12 @@ export default class Compilation {
           this._preparedModel = await this._device.prepareModel(this._model);
         } else {
           this._preparedModel = new TfjsModel(this._model);
-          await this._preparedModel.prepareModel();  
+          await this._preparedModel.prepareModel();
         }
       } break;
-      case 'WebGL': {
-        this._preparedModel = new TfjsModel(this._model);
+      case 'WebGL':
+      case 'WebGPU': {
+        this._preparedModel =  new TfjsModel(this._model);
         await this._preparedModel.prepareModel();
       } break;
       default: {

--- a/src/nn/Model.js
+++ b/src/nn/Model.js
@@ -6,7 +6,7 @@ export default class Model {
   /**
    * Create an empty model.
    *
-   * @typedef  {'WebGL' | 'WASM'} Backend
+   * @typedef  {'WebGL' | 'WebGPU' | 'WASM'} Backend
    *
    * @typedef  {Object}      ModelOptions  Options for polyfill only
    * @property {Backend}     backend       Backend selection
@@ -111,7 +111,7 @@ export default class Model {
 
   /**
    * Sets an operand's per channel quantization parameters.
-   * 
+   *
    * @param {number} index - The index of the model operand we're setting.
    * @param {number} params.channelDim - The index of the channel dimension
    * @param {Float32Array} params.scales - The array of scaling values for each channel.
@@ -269,7 +269,7 @@ export default class Model {
     }
 
     if (channelQuant.channelDim >= operand.dimensions.length) {
-      console.error(`Invalid channelDim ${channelDim} for 
+      console.error(`Invalid channelDim ${channelDim} for
           operand dimensions with length ${operand.dimensions.length}`);
       return false;
     }
@@ -288,7 +288,7 @@ export default class Model {
       console.log(`Channle dimension ${channelQuant.channelDim} is underspecified`);
       return false;
     }
-    
+
     for (let i = 0; i < operand.dimensions[channelQuant.channelDim]; i++) {
       if (channelQuant.scales[i] <= 0) {
         console.error(`Invalid value of scales[${i}]`);

--- a/src/nn/NeuralNetworkContext.js
+++ b/src/nn/NeuralNetworkContext.js
@@ -12,6 +12,7 @@ export default class NeuralNetworkContext {
     this._initImplicitPaddingTypes();
     this._initExecutionPreferenceTypes();
     this.supportWebGL = TfjsModel._supportWebGL();
+    this.supportWebGPU = TfjsModel._supportWebGPU();
     this.supportWasm = !!window.WebAssembly;
   }
 
@@ -22,9 +23,11 @@ export default class NeuralNetworkContext {
    */
   async createModel(options = {}) {
     if (options.backend === 'WebGL' && !this.supportWebGL) {
-      return "WebGL is not available";
+      throw new Error("WebGL is not available");
+    } else if (options.backend === 'WebGPU' && !this.supportWebGPU ) {
+      throw new Error("WebGPU is not available");
     } else if (!this.supportWasm) {
-      return "WebAssembly is not available";
+      throw new Error("WebAssembly is not available");
     }
     return new Model(options);
   }


### PR DESCRIPTION
@huningxin @ibelem PTAL, thanks. 
I use **require** to instead of **import** for '@tensorflow/tfjs-backend-webgpu' model, now if browser didn't support WebGPU, there's an error 'WebGPU is not available'.
```js
  static _supportWebGPU() {
    if (navigator.gpu === undefined) {
      return false;
    } else {
      let tfjsBackendWebgpu = require("@tensorflow/tfjs-backend-webgpu");
      tf.setBackend('webgpu');
      tf.ready();
      return tf.getBackend() === "webgpu";
    }
  }
```