### PR TITLE
[Example] Fix favicon 404 issue in new Chrome browser

### DIFF
--- a/examples/static/img/favicon/site.webmanifest
+++ b/examples/static/img/favicon/site.webmanifest
@@ -1,1 +1,19 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "",
+  "short_name": "",
+  "icons": [
+    {
+      "src": "./android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "./android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff",
+  "display": "standalone"
+}


### PR DESCRIPTION
It will show HTTP 404 for android-chrome-192x192.png in Chrome 85 when visiting https://intel.github.io/webml-polyfill/examples/, this PR just fix this error.

@BruceDai PTAL. It's been fixed in gh-pages branch.